### PR TITLE
Add launch screen storyboard to fix startup requirements

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -20,6 +20,8 @@
     <string>1.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UIApplicationSceneManifest</key>

--- a/Kurani.xcodeproj/project.pbxproj
+++ b/Kurani.xcodeproj/project.pbxproj
@@ -34,17 +34,19 @@
 		D47AD4DA2A6B02A300000053 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000037 /* ContentView.swift */; };
 		D47AD4DA2A6B02A300000054 /* SignInPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000038 /* SignInPromptView.swift */; };
 		D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000019 /* Assets.xcassets */; };
-		D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000020 /* QuranMeta.json */; };
-		D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000021 /* sample_translation.json */; };
-		D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000039 /* Localizable.strings */; };
+                D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000020 /* QuranMeta.json */; };
+                D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000021 /* sample_translation.json */; };
+                D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D47AD4DA2A6B02A300000039 /* Localizable.strings */; };
+                D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D4FA5A8D2B12345600000060 /* LaunchScreen.storyboard */; };
 		D47AD4DA2A6B02A300000059 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = D47AD4DA2A6B02A30000005B /* Supabase */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		D47AD4DA2A6B02A300000019 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		D47AD4DA2A6B02A30000001A /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
-		D47AD4DA2A6B02A30000001B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D47AD4DA2A6B02A30000001C /* Kurani.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kurani.app; sourceTree = BUILT_PRODUCTS_DIR; };
+                D47AD4DA2A6B02A300000019 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+                D47AD4DA2A6B02A30000001A /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+                D47AD4DA2A6B02A30000001B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                D4FA5A8D2B12345600000060 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+                D47AD4DA2A6B02A30000001C /* Kurani.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Kurani.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D47AD4DA2A6B02A30000001D /* QuranApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuranApp.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A30000001E /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A30000001F /* TranslationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationStore.swift; sourceTree = "<group>"; };
@@ -190,13 +192,14 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
-		D47AD4DA2A6B02A300000015 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				D47AD4DA2A6B02A300000019 /* Assets.xcassets */,
-				D47AD4DA2A6B02A300000039 /* Localizable.strings */,
-			);
-			path = Resources;
+                D47AD4DA2A6B02A300000015 /* Resources */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D4FA5A8D2B12345600000060 /* LaunchScreen.storyboard */,
+                                D47AD4DA2A6B02A300000019 /* Assets.xcassets */,
+                                D47AD4DA2A6B02A300000039 /* Localizable.strings */,
+                        );
+                        path = Resources;
 			sourceTree = "<group>";
 		};
 		D47AD4DA2A6B02A300000016 /* Products */ = {
@@ -266,11 +269,12 @@
 		D47AD4DA2A6B02A30000000B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */,
-				D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */,
-				D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */,
-				D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
+                        files = (
+                                D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */,
+                                D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */,
+                                D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */,
+                                D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */,
+                                D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/LaunchScreen.storyboard
+++ b/Resources/LaunchScreen.storyboard
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Kurani" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f9t-eM-q5W">
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="34"/>
+                                <color key="textColor" name="labelColor" catalog="System"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" name="systemBackgroundColor" catalog="System"/>
+                        <constraints>
+                            <constraint firstItem="f9t-eM-q5W" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="2wL-1d-y6x"/>
+                            <constraint firstItem="f9t-eM-q5W" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="LQ0-mM-IOj"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
## Summary
- add a launch screen storyboard with basic branding and constraints
- register the storyboard in the Xcode project and Info.plist so the app has a launch interface

## Testing
- not run (iOS tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5fd04bce88331b8173e35a9a217e9