### PR TITLE
Fix color asset symbol collisions

### DIFF
--- a/App/Theme.swift
+++ b/App/Theme.swift
@@ -1,33 +1,33 @@
 import SwiftUI
 
 enum KuraniTheme {
-    static let background = Color.darkBackground
-    static let surface = Color.primarySurface
-    static let primary = Color.primaryBrand
-    static let accent = Color.accentBrand
-    static let accentLight = Color.accentLight
+    static let background = Color.kuraniDarkBackground
+    static let surface = Color.kuraniPrimarySurface
+    static let primary = Color.kuraniPrimaryBrand
+    static let accent = Color.kuraniAccentBrand
+    static let accentLight = Color.kuraniAccentLight
 
     static let headerGradient = LinearGradient(
-        colors: [Color.primaryBrand, Color.accentBrand],
+        colors: [Color.kuraniPrimaryBrand, Color.kuraniAccentBrand],
         startPoint: .leading,
         endPoint: .trailing
     )
 
     static let accentGradient = LinearGradient(
-        colors: [Color.accentBrand, Color.primaryBrand],
+        colors: [Color.kuraniAccentBrand, Color.kuraniPrimaryBrand],
         startPoint: .top,
         endPoint: .bottom
     )
 }
 
 extension Color {
-    static let darkBackground = Color("DarkBackground")
-    static let primarySurface = Color("PrimarySurface")
-    static let primaryBrand = Color("Primary")
-    static let accentBrand = Color("Accent")
-    static let accentLight = Color("AccentLight")
-    static let textPrimary = Color("TextPrimary")
-    static let textSecondary = Color("TextSecondary")
+    static let kuraniDarkBackground = Color("DarkBackground")
+    static let kuraniPrimarySurface = Color("PrimarySurface")
+    static let kuraniPrimaryBrand = Color("Primary")
+    static let kuraniAccentBrand = Color("Accent")
+    static let kuraniAccentLight = Color("AccentLight")
+    static let kuraniTextPrimary = Color("TextPrimary")
+    static let kuraniTextSecondary = Color("TextSecondary")
 }
 
 struct BrandHeader: View {
@@ -39,11 +39,11 @@ struct BrandHeader: View {
             Text(titleKey)
                 .font(.system(.largeTitle, design: .rounded))
                 .fontWeight(.bold)
-                .foregroundColor(.textPrimary)
+                .foregroundColor(.kuraniTextPrimary)
             if let subtitle {
                 Text(subtitle)
                     .font(.system(.subheadline, design: .rounded))
-                    .foregroundColor(.textSecondary)
+                    .foregroundColor(.kuraniTextSecondary)
             }
         }
         .padding()
@@ -63,9 +63,9 @@ struct Pill: View {
             .fontWeight(.semibold)
             .padding(.vertical, 4)
             .padding(.horizontal, 8)
-            .background(Color.primarySurface.opacity(0.8))
+            .background(Color.kuraniPrimarySurface.opacity(0.8))
             .clipShape(Capsule())
-            .foregroundColor(.accentLight)
+            .foregroundColor(.kuraniAccentLight)
     }
 }
 
@@ -77,7 +77,7 @@ struct GradientButtonStyle: ButtonStyle {
             .frame(maxWidth: .infinity)
             .background(
                 LinearGradient(
-                    colors: [Color.primaryBrand, Color.accentBrand],
+                    colors: [Color.kuraniPrimaryBrand, Color.kuraniAccentBrand],
                     startPoint: .leading,
                     endPoint: .trailing
                 )
@@ -96,8 +96,8 @@ struct ToastView: View {
             .fontWeight(.medium)
             .padding(.horizontal, 24)
             .padding(.vertical, 12)
-            .background(Color.primarySurface.opacity(0.95))
-            .foregroundColor(.textPrimary)
+            .background(Color.kuraniPrimarySurface.opacity(0.95))
+            .foregroundColor(.kuraniTextPrimary)
             .clipShape(Capsule())
             .shadow(radius: 12)
     }

--- a/Views/Components/SignInPromptView.swift
+++ b/Views/Components/SignInPromptView.swift
@@ -26,19 +26,19 @@ struct SignInPromptView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
 
                     Divider()
-                        .background(Color.accentLight.opacity(0.4))
+                        .background(Color.kuraniAccentLight.opacity(0.4))
 
                     VStack(alignment: .leading, spacing: 8) {
                         Text(LocalizedStringKey("signin.email"))
                             .font(.system(.caption, design: .rounded))
-                            .foregroundColor(.textSecondary)
+                            .foregroundColor(.kuraniTextSecondary)
                         TextField(LocalizedStringKey("signin.email.placeholder"), text: $email)
                             .textInputAutocapitalization(.never)
                             .keyboardType(.emailAddress)
                             .padding(12)
-                            .background(Color.primarySurface.opacity(0.4))
+                            .background(Color.kuraniPrimarySurface.opacity(0.4))
                             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                            .foregroundColor(.textPrimary)
+                            .foregroundColor(.kuraniTextPrimary)
                         Button {
                             Task { await sendMagicLink() }
                         } label: {
@@ -50,13 +50,13 @@ struct SignInPromptView: View {
                     }
                 }
                 .padding()
-                .background(Color.primarySurface.opacity(0.3))
+                .background(Color.kuraniPrimarySurface.opacity(0.3))
                 .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
 
                 Spacer()
             }
             .padding()
-            .background(Color.darkBackground.ignoresSafeArea())
+            .background(Color.kuraniDarkBackground.ignoresSafeArea())
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(LocalizedStringKey("action.cancel")) { dismiss() }

--- a/Views/LibraryView.swift
+++ b/Views/LibraryView.swift
@@ -33,17 +33,17 @@ struct LibraryView: View {
                                 VStack(alignment: .leading, spacing: 4) {
                                     Text(String(format: NSLocalizedString("reader.title.compact", comment: "title"), lastRead.surah, translationStore.title(for: lastRead.surah)))
                                         .font(.system(.headline, design: .rounded))
-                                        .foregroundColor(.textPrimary)
+                                        .foregroundColor(.kuraniTextPrimary)
                                     Text(LocalizedStringKey("library.continueReading"))
                                         .font(.system(.subheadline, design: .rounded))
-                                        .foregroundColor(.textSecondary)
+                                        .foregroundColor(.kuraniTextSecondary)
                                 }
                                 Spacer()
                                 Image(systemName: "arrow.right")
                                     .foregroundColor(.accentBrand)
                             }
                         }
-                        .listRowBackground(Color.primarySurface)
+                        .listRowBackground(Color.kuraniPrimarySurface)
                     }
                 }
 
@@ -52,13 +52,13 @@ struct LibraryView: View {
                         NavigationLink(value: ReaderRoute(surah: surah.number, ayah: nil)) {
                             SurahRow(surah: surah)
                         }
-                        .listRowBackground(Color.primarySurface)
+                        .listRowBackground(Color.kuraniPrimarySurface)
                     }
                 }
             }
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
-            .background(Color.darkBackground)
+            .background(Color.kuraniDarkBackground)
             .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: LocalizedStringKey("library.search.placeholder"))
             .navigationTitle(LocalizedStringKey("tabs.library"))
             .toolbar {

--- a/Views/NoteEditorView.swift
+++ b/Views/NoteEditorView.swift
@@ -14,18 +14,18 @@ struct NoteEditorView: View {
             VStack(alignment: .leading, spacing: 16) {
                 Text(String(format: NSLocalizedString("reader.title.compact", comment: "title"), ayah.number, ayah.text))
                     .font(.system(.subheadline, design: .rounded))
-                    .foregroundColor(.textSecondary)
+                    .foregroundColor(.kuraniTextSecondary)
 
                 TextEditor(text: $draft)
                     .focused($isFocused)
                     .frame(minHeight: 160)
                     .padding(8)
-                    .background(Color.primarySurface.opacity(0.4))
+                    .background(Color.kuraniPrimarySurface.opacity(0.4))
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    .foregroundColor(.textPrimary)
+                    .foregroundColor(.kuraniTextPrimary)
             }
             .padding()
-            .background(Color.darkBackground.ignoresSafeArea())
+            .background(Color.kuraniDarkBackground.ignoresSafeArea())
             .navigationTitle(draft.isEmpty ? LocalizedStringKey("reader.note.add") : LocalizedStringKey("reader.note.edit"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/Views/NotesView.swift
+++ b/Views/NotesView.swift
@@ -61,26 +61,26 @@ struct NotesView: View {
                                         VStack(alignment: .leading, spacing: 8) {
                                             Text(note.text)
                                                 .font(.system(.body, design: .rounded))
-                                                .foregroundColor(.textPrimary)
+                                                .foregroundColor(.kuraniTextPrimary)
                                                 .lineLimit(3)
                                             Text(String(format: NSLocalizedString("notes.lastUpdated", comment: "updated"), formatted(date: note.updatedAt)))
                                                 .font(.system(.caption, design: .rounded))
-                                                .foregroundColor(.textSecondary)
+                                                .foregroundColor(.kuraniTextSecondary)
                                         }
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                     }
-                                    .listRowBackground(Color.primarySurface)
+                                    .listRowBackground(Color.kuraniPrimarySurface)
                                 }
                             }
-                            .listRowBackground(Color.primarySurface)
+                            .listRowBackground(Color.kuraniPrimarySurface)
                         }
                     }
                     .listStyle(.insetGrouped)
                     .scrollContentBackground(.hidden)
-                    .background(Color.darkBackground)
+                    .background(Color.kuraniDarkBackground)
                 }
             }
-            .background(Color.darkBackground.ignoresSafeArea())
+            .background(Color.kuraniDarkBackground.ignoresSafeArea())
             .navigationTitle(LocalizedStringKey("notes.title"))
             .sheet(isPresented: $showingSignInSheet) {
                 SignInPromptView()

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -39,7 +39,7 @@ struct ReaderView: View {
 
                                 Text(ayah.text)
                                     .font(.system(size: 18 * viewModel.fontScale, weight: .regular, design: .serif))
-                                    .foregroundColor(.textPrimary)
+                                    .foregroundColor(.kuraniTextPrimary)
                                     .lineSpacing(6 * viewModel.lineSpacingScale)
                                     .contextMenu {
                                         Button(LocalizedStringKey("action.edit")) {
@@ -63,19 +63,19 @@ struct ReaderView: View {
                                         .foregroundColor(.accentBrand)
                                     Text(String(format: NSLocalizedString("reader.noteBanner", comment: "banner"), noteFormatter.string(from: note.updatedAt)))
                                         .font(.system(.caption, design: .rounded))
-                                        .foregroundColor(.textSecondary)
+                                        .foregroundColor(.kuraniTextSecondary)
                                 }
                                 .padding(10)
-                                .background(Color.primarySurface.opacity(0.6))
+                                .background(Color.kuraniPrimarySurface.opacity(0.6))
                                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                             }
                         }
                         .padding()
-                        .background(Color.primarySurface.opacity(0.5))
+                        .background(Color.kuraniPrimarySurface.opacity(0.5))
                         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                         .overlay(
                             RoundedRectangle(cornerRadius: 16)
-                                .stroke(Color.primarySurface.opacity(0.2), lineWidth: 1)
+                                .stroke(Color.kuraniPrimarySurface.opacity(0.2), lineWidth: 1)
                         )
                         .id(ayah.number)
                         .onAppear {
@@ -86,9 +86,9 @@ struct ReaderView: View {
                 .padding(.horizontal)
                 .padding(.bottom, 40)
             }
-            .background(Color.darkBackground.ignoresSafeArea())
+            .background(Color.kuraniDarkBackground.ignoresSafeArea())
             .navigationTitle(Text(viewModel.surahTitle))
-            .toolbarBackground(Color.darkBackground, for: .navigationBar)
+            .toolbarBackground(Color.kuraniDarkBackground, for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -27,14 +27,14 @@ struct RootView: View {
             LibraryView(viewModel: libraryViewModel) {
                 selectedTab = .notes
             }
-            .background(Color.darkBackground.ignoresSafeArea())
+            .background(Color.kuraniDarkBackground.ignoresSafeArea())
             .tabItem {
                 Label(LocalizedStringKey("tabs.library"), systemImage: "book")
             }
             .tag(Tab.library)
 
             NotesView(viewModel: notesViewModel, translationStore: translationStore)
-            .background(Color.darkBackground.ignoresSafeArea())
+            .background(Color.kuraniDarkBackground.ignoresSafeArea())
             .tabItem {
                 Label(LocalizedStringKey("tabs.notes"), systemImage: "note.text")
             }
@@ -42,12 +42,12 @@ struct RootView: View {
 
             SettingsView(viewModel: settingsViewModel)
                 .environmentObject(authManager)
-                .background(Color.darkBackground.ignoresSafeArea())
+                .background(Color.kuraniDarkBackground.ignoresSafeArea())
             .tabItem {
                 Label(LocalizedStringKey("tabs.settings"), systemImage: "gearshape")
             }
             .tag(Tab.settings)
         }
-        .tint(Color.accentBrand)
+        .tint(Color.kuraniAccentBrand)
     }
 }

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -15,14 +15,14 @@ struct SettingsView: View {
                     if let user = authManager.user {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(user.email ?? "")
-                                .foregroundColor(.textPrimary)
+                                .foregroundColor(.kuraniTextPrimary)
                             Text(user.id.uuidString)
                                 .font(.system(.caption, design: .monospaced))
-                                .foregroundColor(.textSecondary)
+                                .foregroundColor(.kuraniTextSecondary)
                         }
                     } else {
                         Text(LocalizedStringKey("notes.signinRequired"))
-                            .foregroundColor(.textSecondary)
+                            .foregroundColor(.kuraniTextSecondary)
                     }
 
                     if authManager.userId == nil {
@@ -36,12 +36,12 @@ struct SettingsView: View {
                         .foregroundColor(.red)
                     }
                 }
-                .listRowBackground(Color.primarySurface)
+                .listRowBackground(Color.kuraniPrimarySurface)
 
                 Section(header: Text(LocalizedStringKey("settings.translation"))) {
                     HStack {
                         Text(viewModel.isUsingSampleTranslation ? LocalizedStringKey("settings.translation.sample") : LocalizedStringKey("settings.translation.loaded"))
-                            .foregroundColor(.textSecondary)
+                            .foregroundColor(.kuraniTextSecondary)
                         Spacer()
                         if viewModel.isImporting {
                             ProgressView()
@@ -52,25 +52,25 @@ struct SettingsView: View {
                         showingImporter = true
                     }
                 }
-                .listRowBackground(Color.primarySurface)
+                .listRowBackground(Color.kuraniPrimarySurface)
 
                 Section(header: Text(LocalizedStringKey("settings.about"))) {
                     Text(LocalizedStringKey("settings.about.disclaimer"))
-                        .foregroundColor(.textSecondary)
+                        .foregroundColor(.kuraniTextSecondary)
                     HStack {
                         Text(LocalizedStringKey("settings.version"))
                         Spacer()
                         Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
-                            .foregroundColor(.textSecondary)
+                            .foregroundColor(.kuraniTextSecondary)
                     }
                 }
-                .listRowBackground(Color.primarySurface)
+                .listRowBackground(Color.kuraniPrimarySurface)
             }
             .scrollContentBackground(.hidden)
-            .background(Color.darkBackground)
-            .tint(Color.accentBrand)
+            .background(Color.kuraniDarkBackground)
+            .tint(Color.kuraniAccentBrand)
             .navigationTitle(LocalizedStringKey("settings.title"))
-            .toolbarBackground(Color.darkBackground, for: .navigationBar)
+            .toolbarBackground(Color.kuraniDarkBackground, for: .navigationBar)
             .fileImporter(isPresented: $showingImporter, allowedContentTypes: [.json]) { result in
                 switch result {
                 case .success(let url):

--- a/Views/SurahRow.swift
+++ b/Views/SurahRow.swift
@@ -9,10 +9,10 @@ struct SurahRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(surah.name)
                     .font(.system(.headline, design: .rounded))
-                    .foregroundColor(.textPrimary)
+                    .foregroundColor(.kuraniTextPrimary)
                 Text("\(surah.ayahCount) \(LocalizedStringKey("library.ayahs"))")
                     .font(.system(.caption, design: .rounded))
-                    .foregroundColor(.textSecondary)
+                    .foregroundColor(.kuraniTextSecondary)
             }
             Spacer()
             Image(systemName: "chevron.right")


### PR DESCRIPTION
## Summary
- rename custom Color helpers with a Kurani-specific prefix to avoid clashes with generated asset symbols
- update theme gradients and all view usages to call the new prefixed color helpers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d60cd010388331955d36e52717625c