### PR TITLE
Restore Color.accentBrand alias

### DIFF
--- a/App/Theme.swift
+++ b/App/Theme.swift
@@ -28,6 +28,9 @@ extension Color {
     static let kuraniAccentLight = Color("AccentLight")
     static let kuraniTextPrimary = Color("TextPrimary")
     static let kuraniTextSecondary = Color("TextSecondary")
+
+    // Backwards compatibility alias for older usages in the codebase
+    static let accentBrand = Color.kuraniAccentBrand
 }
 
 struct BrandHeader: View {


### PR DESCRIPTION
## Summary
- add a backwards-compatible alias for `Color.accentBrand`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d616c70e7483318f2d23bc76708b0f