### PR TITLE
Remove empty scene configuration from Info.plist

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -22,25 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
-		<key>UISceneConfigurations</key>
-		<dict>
-			<key>UIWindowSceneSessionRoleApplication</key>
-			<array>
-				<dict>
-					<key>UISceneConfigurationName</key>
-					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string></string>
-					<key>UISceneStoryboardFile</key>
-					<string></string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
## Summary
- remove the empty scene configuration and storyboard entries from Info.plist
- disable multi-scene support to let the SwiftUI App lifecycle handle scene creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61d3b0ed08331a5bff9374d2c17c8