### PR TITLE
Remove empty scene configuration keys from Info.plist

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -33,10 +33,6 @@
 				<dict>
 					<key>UISceneConfigurationName</key>
 					<string>Default Configuration</string>
-					<key>UISceneDelegateClassName</key>
-					<string></string>
-					<key>UISceneStoryboardFile</key>
-					<string></string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
## Summary
- remove the empty UISceneDelegateClassName and UISceneStoryboardFile keys from the app's Info.plist to prevent runtime crashes when loading scenes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61f70bf5883318689c745a579df19