### PR TITLE
feat: refresh UI with Apple-inspired styling

### DIFF
--- a/App/Theme.swift
+++ b/App/Theme.swift
@@ -7,14 +7,24 @@ enum KuraniTheme {
     static let accent = Color.kuraniAccentBrand
     static let accentLight = Color.kuraniAccentLight
 
+    static let backgroundGradient = LinearGradient(
+        colors: [
+            Color.kuraniDarkBackground,
+            Color.kuraniPrimarySurface.opacity(0.45),
+            Color.kuraniDarkBackground.opacity(0.92)
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
     static let headerGradient = LinearGradient(
-        colors: [Color.kuraniPrimaryBrand, Color.kuraniAccentBrand],
-        startPoint: .leading,
-        endPoint: .trailing
+        colors: [Color.kuraniPrimaryBrand, Color.kuraniAccentLight, Color.kuraniAccentBrand],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
     )
 
     static let accentGradient = LinearGradient(
-        colors: [Color.kuraniAccentBrand, Color.kuraniPrimaryBrand],
+        colors: [Color.kuraniAccentBrand, Color.kuraniAccentLight],
         startPoint: .top,
         endPoint: .bottom
     )
@@ -38,10 +48,10 @@ struct BrandHeader: View {
     var subtitle: LocalizedStringKey?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Text(titleKey)
                 .font(.system(.largeTitle, design: .rounded))
-                .fontWeight(.bold)
+                .fontWeight(.semibold)
                 .foregroundColor(.kuraniTextPrimary)
             if let subtitle {
                 Text(subtitle)
@@ -49,11 +59,19 @@ struct BrandHeader: View {
                     .foregroundColor(.kuraniTextSecondary)
             }
         }
-        .padding()
+        .padding(.vertical, 24)
+        .padding(.horizontal, 26)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(KuraniTheme.headerGradient)
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .shadow(color: Color.black.opacity(0.3), radius: 8, y: 6)
+        .background(
+            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                .fill(KuraniTheme.headerGradient)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 30, style: .continuous)
+                        .stroke(Color.white.opacity(0.15), lineWidth: 1.2)
+                )
+                .shadow(color: Color.black.opacity(0.45), radius: 24, y: 16)
+        )
+        .padding(.horizontal, 4)
     }
 }
 
@@ -62,31 +80,52 @@ struct Pill: View {
 
     var body: some View {
         Text("\(number)")
-            .font(.system(.caption, design: .rounded))
+            .font(.system(.subheadline, design: .rounded))
             .fontWeight(.semibold)
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .background(Color.kuraniPrimarySurface.opacity(0.8))
-            .clipShape(Capsule())
-            .foregroundColor(.kuraniAccentLight)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 12)
+            .foregroundColor(.kuraniTextPrimary)
+            .background(
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [Color.kuraniAccentLight.opacity(0.9), Color.kuraniAccentBrand.opacity(0.9)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+            )
+            .overlay(
+                Capsule()
+                    .stroke(Color.white.opacity(0.25), lineWidth: 0.8)
+            )
+            .shadow(color: Color.black.opacity(0.25), radius: 12, y: 6)
     }
 }
 
 struct GradientButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .padding(.vertical, 12)
-            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .padding(.horizontal, 20)
             .frame(maxWidth: .infinity)
             .background(
-                LinearGradient(
-                    colors: [Color.kuraniPrimaryBrand, Color.kuraniAccentBrand],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(KuraniTheme.accentGradient)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .fill(
+                                LinearGradient(
+                                    colors: [Color.white.opacity(0.25), Color.white.opacity(0)],
+                                    startPoint: .top,
+                                    endPoint: .bottom
+                                )
+                            )
+                    )
             )
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-            .opacity(configuration.isPressed ? 0.8 : 1.0)
+            .shadow(color: Color.black.opacity(configuration.isPressed ? 0.15 : 0.35), radius: 16, y: 12)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.spring(response: 0.36, dampingFraction: 0.8), value: configuration.isPressed)
     }
 }
 
@@ -103,5 +142,31 @@ struct ToastView: View {
             .foregroundColor(.kuraniTextPrimary)
             .clipShape(Capsule())
             .shadow(radius: 12)
+    }
+}
+
+private struct AppleCardBackground: ViewModifier {
+    var cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .padding(.vertical, 18)
+            .padding(.horizontal, 20)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(Color.kuraniPrimarySurface.opacity(0.82))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .stroke(Color.white.opacity(0.08), lineWidth: 0.8)
+                    )
+                    .shadow(color: Color.black.opacity(0.35), radius: 20, y: 14)
+            )
+    }
+}
+
+extension View {
+    func appleCard(cornerRadius: CGFloat = 24) -> some View {
+        modifier(AppleCardBackground(cornerRadius: cornerRadius))
     }
 }

--- a/Resources/Assets.xcassets/Accent Color.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.114",
-          "green" : "0.949",
-          "blue" : "0.867"
+          "red" : "0.776",
+          "green" : "0.294",
+          "blue" : "0.227"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/Accent.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "info" : {"author" : "xcode", "version" : 1},
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.114",
-          "green" : "0.949",
-          "blue" : "0.867"
+          "red" : "0.776",
+          "green" : "0.294",
+          "blue" : "0.227"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
+++ b/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "info" : {"author" : "xcode", "version" : 1},
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.627",
-          "green" : "0.949",
-          "blue" : "0.949"
+          "red" : "0.957",
+          "green" : "0.757",
+          "blue" : "0.376"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
+++ b/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
@@ -1,17 +1,20 @@
 {
-  "info" : {"author" : "xcode", "version" : 1},
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.043",
-          "green" : "0.141",
-          "blue" : "0.149"
+          "red" : "0.169",
+          "green" : "0.161",
+          "blue" : "0.169"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/Resources/Assets.xcassets/Primary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Primary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.067",
-          "green" : "0.549",
-          "blue" : "0.549"
+          "red" : "0.184",
+          "green" : "0.478",
+          "blue" : "0.502"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
+++ b/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.067",
-          "green" : "0.322",
-          "blue" : "0.349"
+          "red" : "0.122",
+          "green" : "0.302",
+          "blue" : "0.400"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/TextPrimary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/TextPrimary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.627",
-          "green" : "0.949",
-          "blue" : "0.949"
+          "red" : "0.961",
+          "green" : "0.953",
+          "blue" : "0.925"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.800",
-          "red" : "0.114",
-          "green" : "0.949",
-          "blue" : "0.867"
+          "alpha" : "1.000",
+          "red" : "0.682",
+          "green" : "0.725",
+          "blue" : "0.773"
         }
       },
       "idiom" : "universal"

--- a/Views/Components/SignInPromptView.swift
+++ b/Views/Components/SignInPromptView.swift
@@ -13,6 +13,7 @@ struct SignInPromptView: View {
         NavigationStack {
             VStack(spacing: 24) {
                 BrandHeader(titleKey: "notes.signInPrompt", subtitle: "notes.noAccess")
+                    .padding(.horizontal, 12)
                     .padding(.top)
 
                 VStack(spacing: 16) {
@@ -21,9 +22,10 @@ struct SignInPromptView: View {
                     } onCompletion: { result in
                         Task { await authManager.handleAppleCompletion(result) }
                     }
-                    .signInWithAppleButtonStyle(.whiteOutline)
-                    .frame(height: 50)
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .signInWithAppleButtonStyle(.white)
+                    .frame(height: 54)
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .shadow(color: Color.black.opacity(0.25), radius: 18, y: 12)
 
                     Divider()
                         .background(Color.kuraniAccentLight.opacity(0.4))
@@ -35,9 +37,9 @@ struct SignInPromptView: View {
                         TextField(LocalizedStringKey("signin.email.placeholder"), text: $email)
                             .textInputAutocapitalization(.never)
                             .keyboardType(.emailAddress)
-                            .padding(12)
-                            .background(Color.kuraniPrimarySurface.opacity(0.4))
-                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .padding(14)
+                            .background(Color.kuraniPrimarySurface.opacity(0.45))
+                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                             .foregroundColor(.kuraniTextPrimary)
                         Button {
                             Task { await sendMagicLink() }
@@ -49,17 +51,17 @@ struct SignInPromptView: View {
                         .disabled(email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSendingEmail)
                     }
                 }
-                .padding()
-                .background(Color.kuraniPrimarySurface.opacity(0.3))
-                .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                .appleCard(cornerRadius: 26)
+                .padding(.horizontal, 8)
 
                 Spacer()
             }
             .padding()
-            .background(Color.kuraniDarkBackground.ignoresSafeArea())
+            .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(LocalizedStringKey("action.cancel")) { dismiss() }
+                        .tint(.kuraniAccentLight)
                 }
             }
             .onReceive(authManager.$userId) { userId in
@@ -78,7 +80,9 @@ struct SignInPromptView: View {
                 }
             }
         }
+        .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
     }
+}
 
     @MainActor
     private func sendMagicLink() async {

--- a/Views/LibraryView.swift
+++ b/Views/LibraryView.swift
@@ -22,6 +22,7 @@ struct LibraryView: View {
                     BrandHeader(titleKey: "tabs.library", subtitle: "library.sampleOnly")
                         .listRowInsets(EdgeInsets())
                         .listRowBackground(Color.clear)
+                        .padding(.vertical, 8)
                 }
 
                 if let lastRead = viewModel.lastRead {
@@ -42,8 +43,13 @@ struct LibraryView: View {
                                 Image(systemName: "arrow.right")
                                     .foregroundColor(.accentBrand)
                             }
+                            .appleCard()
+                            .padding(.horizontal, 20)
                         }
-                        .listRowBackground(Color.kuraniPrimarySurface)
+                        .buttonStyle(.plain)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                        .padding(.vertical, 6)
                     }
                 }
 
@@ -51,20 +57,28 @@ struct LibraryView: View {
                     ForEach(viewModel.filteredSurahs) { surah in
                         NavigationLink(value: ReaderRoute(surah: surah.number, ayah: nil)) {
                             SurahRow(surah: surah)
+                                .appleCard()
+                                .padding(.horizontal, 20)
                         }
-                        .listRowBackground(Color.kuraniPrimarySurface)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                        .padding(.vertical, 6)
                     }
                 }
             }
             .listStyle(.insetGrouped)
+            .listSectionSpacing(20)
             .scrollContentBackground(.hidden)
-            .background(Color.kuraniDarkBackground)
+            .listRowSeparator(.hidden)
+            .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
             .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: LocalizedStringKey("library.search.placeholder"))
             .navigationTitle(LocalizedStringKey("tabs.library"))
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: openNotesTab) {
                         Label(LocalizedStringKey("reader.notesButton"), systemImage: "note.text")
+                            .labelStyle(.titleAndIcon)
+                            .foregroundStyle(Color.kuraniAccentLight)
                     }
                 }
             }
@@ -80,5 +94,6 @@ struct LibraryView: View {
                 viewModel.refreshLastRead()
             }
         }
+        .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
     }
 }

--- a/Views/NoteEditorView.swift
+++ b/Views/NoteEditorView.swift
@@ -11,21 +11,30 @@ struct NoteEditorView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 20) {
                 Text(String(format: NSLocalizedString("reader.title.compact", comment: "title"), ayah.number, ayah.text))
                     .font(.system(.subheadline, design: .rounded))
                     .foregroundColor(.kuraniTextSecondary)
 
                 TextEditor(text: $draft)
                     .focused($isFocused)
-                    .frame(minHeight: 160)
-                    .padding(8)
-                    .background(Color.kuraniPrimarySurface.opacity(0.4))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .frame(minHeight: 220)
+                    .padding(.vertical, 18)
+                    .padding(.horizontal, 16)
+                    .background(
+                        RoundedRectangle(cornerRadius: 26, style: .continuous)
+                            .fill(Color.kuraniPrimarySurface.opacity(0.58))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                                    .stroke(Color.white.opacity(0.12), lineWidth: 0.8)
+                            )
+                            .shadow(color: Color.black.opacity(0.32), radius: 20, y: 14)
+                    )
                     .foregroundColor(.kuraniTextPrimary)
             }
-            .padding()
-            .background(Color.kuraniDarkBackground.ignoresSafeArea())
+            .padding(.horizontal, 20)
+            .padding(.vertical, 24)
+            .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
             .navigationTitle(draft.isEmpty ? LocalizedStringKey("reader.note.add") : LocalizedStringKey("reader.note.edit"))
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -45,6 +54,7 @@ struct NoteEditorView: View {
                     .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
                 }
             }
+            .tint(.kuraniAccentLight)
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     isFocused = true

--- a/Views/NotesView.swift
+++ b/Views/NotesView.swift
@@ -21,6 +21,7 @@ struct NotesView: View {
                 if authManager.userId == nil {
                     VStack(spacing: 24) {
                         BrandHeader(titleKey: "notes.title", subtitle: "notes.signinRequired")
+                            .padding(.horizontal, 16)
                         Button {
                             showingSignInSheet = true
                         } label: {
@@ -35,12 +36,13 @@ struct NotesView: View {
                     VStack(spacing: 16) {
                         ProgressView(LocalizedStringKey("notes.loading"))
                             .progressViewStyle(.circular)
-                            .tint(.accentBrand)
+                            .tint(.kuraniAccentLight)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if viewModel.sortedSurahNumbers.isEmpty {
                     VStack(spacing: 16) {
                         BrandHeader(titleKey: "notes.title", subtitle: "notes.empty")
+                            .padding(.horizontal, 16)
                         Spacer()
                     }
                     .padding()
@@ -50,6 +52,7 @@ struct NotesView: View {
                             BrandHeader(titleKey: "notes.title", subtitle: "notes.openReader")
                                 .listRowInsets(EdgeInsets())
                                 .listRowBackground(Color.clear)
+                                .padding(.vertical, 8)
                         }
 
                         ForEach(viewModel.sortedSurahNumbers, id: \.self) { surahNumber in
@@ -67,20 +70,26 @@ struct NotesView: View {
                                                 .font(.system(.caption, design: .rounded))
                                                 .foregroundColor(.kuraniTextSecondary)
                                         }
-                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .appleCard(cornerRadius: 20)
+                                        .padding(.horizontal, 20)
                                     }
-                                    .listRowBackground(Color.kuraniPrimarySurface)
+                                    .buttonStyle(.plain)
+                                    .listRowInsets(EdgeInsets())
+                                    .listRowBackground(Color.clear)
+                                    .padding(.vertical, 6)
                                 }
                             }
-                            .listRowBackground(Color.kuraniPrimarySurface)
+                            .listRowBackground(Color.clear)
                         }
                     }
                     .listStyle(.insetGrouped)
+                    .listSectionSpacing(20)
                     .scrollContentBackground(.hidden)
-                    .background(Color.kuraniDarkBackground)
+                    .listRowSeparator(.hidden)
+                    .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
                 }
             }
-            .background(Color.kuraniDarkBackground.ignoresSafeArea())
+            .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
             .navigationTitle(LocalizedStringKey("notes.title"))
             .sheet(isPresented: $showingSignInSheet) {
                 SignInPromptView()
@@ -95,6 +104,7 @@ struct NotesView: View {
                 .environmentObject(authManager)
             }
         }
+        .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
     }
 
     private func sectionTitle(for surah: Int) -> String {

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -25,7 +25,7 @@ struct ReaderView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 16) {
+                LazyVStack(alignment: .leading, spacing: 20) {
                     ForEach(viewModel.ayahs) { ayah in
                         VStack(alignment: .leading, spacing: 12) {
                             HStack(alignment: .top, spacing: 12) {
@@ -60,35 +60,36 @@ struct ReaderView: View {
                             if let note = viewModel.note(for: ayah) {
                                 HStack {
                                     Image(systemName: "pencil.and.outline")
-                                        .foregroundColor(.accentBrand)
+                                        .foregroundStyle(Color.kuraniAccentLight)
                                     Text(String(format: NSLocalizedString("reader.noteBanner", comment: "banner"), noteFormatter.string(from: note.updatedAt)))
                                         .font(.system(.caption, design: .rounded))
                                         .foregroundColor(.kuraniTextSecondary)
                                 }
-                                .padding(10)
-                                .background(Color.kuraniPrimarySurface.opacity(0.6))
-                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                .padding(.vertical, 10)
+                                .padding(.horizontal, 14)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                        .fill(Color.kuraniPrimarySurface.opacity(0.68))
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                                .stroke(Color.white.opacity(0.12), lineWidth: 0.6)
+                                        )
+                                )
                             }
                         }
-                        .padding()
-                        .background(Color.kuraniPrimarySurface.opacity(0.5))
-                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(Color.kuraniPrimarySurface.opacity(0.2), lineWidth: 1)
-                        )
+                        .appleCard(cornerRadius: 28)
+                        .padding(.horizontal, 16)
                         .id(ayah.number)
                         .onAppear {
                             viewModel.updateLastRead(ayah: ayah.number)
                         }
                     }
                 }
-                .padding(.horizontal)
-                .padding(.bottom, 40)
+                .padding(.bottom, 56)
             }
-            .background(Color.kuraniDarkBackground.ignoresSafeArea())
+            .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
             .navigationTitle(Text(viewModel.surahTitle))
-            .toolbarBackground(Color.kuraniDarkBackground, for: .navigationBar)
+            .toolbarBackground(Color.kuraniDarkBackground.opacity(0.35), for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -97,18 +98,21 @@ struct ReaderView: View {
                     } label: {
                         Image(systemName: "textformat.size.smaller")
                             .accessibilityLabel(LocalizedStringKey("reader.font.decrease"))
+                            .foregroundStyle(Color.kuraniAccentLight)
                     }
                     Button {
                         viewModel.increaseFont()
                     } label: {
                         Image(systemName: "textformat.size.larger")
                             .accessibilityLabel(LocalizedStringKey("reader.font.increase"))
+                            .foregroundStyle(Color.kuraniAccentLight)
                     }
                     Menu {
                         Button(LocalizedStringKey("reader.lineSpacing.decrease")) { viewModel.decreaseLineSpacing() }
                         Button(LocalizedStringKey("reader.lineSpacing.increase")) { viewModel.increaseLineSpacing() }
                     } label: {
                         Image(systemName: "text.line.first.and.arrowtriangle.forward")
+                            .foregroundStyle(Color.kuraniAccentLight)
                     }
                     .accessibilityLabel(LocalizedStringKey("reader.lineSpacing"))
                     Button {
@@ -119,10 +123,12 @@ struct ReaderView: View {
                         }
                     } label: {
                         Image(systemName: "note.text")
+                            .foregroundStyle(Color.kuraniAccentLight)
                     }
                     .accessibilityLabel(LocalizedStringKey("reader.notesButton"))
                 }
             }
+            .tint(Color.kuraniAccentLight)
             .onAppear {
                 if let startingAyah, viewModel.ayahs.contains(where: { $0.number == startingAyah }) {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
@@ -133,6 +139,7 @@ struct ReaderView: View {
                 }
             }
         }
+        .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
         .sheet(isPresented: $viewModel.isNoteEditorPresented) {
             if let ayah = viewModel.selectedAyah {
                 NoteEditorView(

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -27,14 +27,14 @@ struct RootView: View {
             LibraryView(viewModel: libraryViewModel) {
                 selectedTab = .notes
             }
-            .background(Color.kuraniDarkBackground.ignoresSafeArea())
+            .background(Color.clear)
             .tabItem {
                 Label(LocalizedStringKey("tabs.library"), systemImage: "book")
             }
             .tag(Tab.library)
 
             NotesView(viewModel: notesViewModel, translationStore: translationStore)
-            .background(Color.kuraniDarkBackground.ignoresSafeArea())
+            .background(Color.clear)
             .tabItem {
                 Label(LocalizedStringKey("tabs.notes"), systemImage: "note.text")
             }
@@ -42,12 +42,13 @@ struct RootView: View {
 
             SettingsView(viewModel: settingsViewModel)
                 .environmentObject(authManager)
-                .background(Color.kuraniDarkBackground.ignoresSafeArea())
+                .background(Color.clear)
             .tabItem {
                 Label(LocalizedStringKey("tabs.settings"), systemImage: "gearshape")
             }
             .tag(Tab.settings)
         }
         .tint(Color.kuraniAccentBrand)
+        .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
     }
 }

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -12,65 +12,84 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 Section(header: Text(LocalizedStringKey("settings.account"))) {
-                    if let user = authManager.user {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(user.email ?? "")
-                                .foregroundColor(.kuraniTextPrimary)
-                            Text(user.id.uuidString)
-                                .font(.system(.caption, design: .monospaced))
+                    VStack(alignment: .leading, spacing: 16) {
+                        if let user = authManager.user {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(user.email ?? "")
+                                    .foregroundColor(.kuraniTextPrimary)
+                                Text(user.id.uuidString)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.kuraniTextSecondary)
+                            }
+                        } else {
+                            Text(LocalizedStringKey("notes.signinRequired"))
                                 .foregroundColor(.kuraniTextSecondary)
                         }
-                    } else {
-                        Text(LocalizedStringKey("notes.signinRequired"))
-                            .foregroundColor(.kuraniTextSecondary)
-                    }
 
-                    if authManager.userId == nil {
-                        Button(LocalizedStringKey("settings.signin")) {
-                            showingSignInSheet = true
+                        if authManager.userId == nil {
+                            Button(LocalizedStringKey("settings.signin")) {
+                                showingSignInSheet = true
+                            }
+                            .buttonStyle(GradientButtonStyle())
+                        } else {
+                            Button(LocalizedStringKey("settings.signout")) {
+                                Task { await viewModel.signOut() }
+                            }
+                            .buttonStyle(GradientButtonStyle())
                         }
-                    } else {
-                        Button(LocalizedStringKey("settings.signout")) {
-                            Task { await viewModel.signOut() }
-                        }
-                        .foregroundColor(.red)
                     }
+                    .appleCard()
+                    .padding(.horizontal, 12)
                 }
-                .listRowBackground(Color.kuraniPrimarySurface)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
 
                 Section(header: Text(LocalizedStringKey("settings.translation"))) {
-                    HStack {
-                        Text(viewModel.isUsingSampleTranslation ? LocalizedStringKey("settings.translation.sample") : LocalizedStringKey("settings.translation.loaded"))
-                            .foregroundColor(.kuraniTextSecondary)
-                        Spacer()
-                        if viewModel.isImporting {
-                            ProgressView()
+                    VStack(alignment: .leading, spacing: 16) {
+                        HStack {
+                            Text(viewModel.isUsingSampleTranslation ? LocalizedStringKey("settings.translation.sample") : LocalizedStringKey("settings.translation.loaded"))
+                                .foregroundColor(.kuraniTextSecondary)
+                            Spacer()
+                            if viewModel.isImporting {
+                                ProgressView()
+                                    .tint(.kuraniAccentLight)
+                            }
                         }
-                    }
 
-                    Button(LocalizedStringKey("settings.import")) {
-                        showingImporter = true
+                        Button(LocalizedStringKey("settings.import")) {
+                            showingImporter = true
+                        }
+                        .buttonStyle(GradientButtonStyle())
                     }
+                    .appleCard()
+                    .padding(.horizontal, 12)
                 }
-                .listRowBackground(Color.kuraniPrimarySurface)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
 
                 Section(header: Text(LocalizedStringKey("settings.about"))) {
-                    Text(LocalizedStringKey("settings.about.disclaimer"))
-                        .foregroundColor(.kuraniTextSecondary)
-                    HStack {
-                        Text(LocalizedStringKey("settings.version"))
-                        Spacer()
-                        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(LocalizedStringKey("settings.about.disclaimer"))
                             .foregroundColor(.kuraniTextSecondary)
+                        HStack {
+                            Text(LocalizedStringKey("settings.version"))
+                            Spacer()
+                            Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                                .foregroundColor(.kuraniTextSecondary)
+                        }
                     }
+                    .appleCard()
+                    .padding(.horizontal, 12)
                 }
-                .listRowBackground(Color.kuraniPrimarySurface)
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
             }
             .scrollContentBackground(.hidden)
-            .background(Color.kuraniDarkBackground)
-            .tint(Color.kuraniAccentBrand)
+            .listRowSeparator(.hidden)
+            .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
+            .tint(Color.kuraniAccentLight)
             .navigationTitle(LocalizedStringKey("settings.title"))
-            .toolbarBackground(Color.kuraniDarkBackground, for: .navigationBar)
+            .toolbarBackground(Color.kuraniDarkBackground.opacity(0.4), for: .navigationBar)
             .fileImporter(isPresented: $showingImporter, allowedContentTypes: [.json]) { result in
                 switch result {
                 case .success(let url):
@@ -99,6 +118,7 @@ struct SettingsView: View {
                 }
             }
         }
+        .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
     }
 
     private func importTranslation(url: URL) async {

--- a/Views/SurahRow.swift
+++ b/Views/SurahRow.swift
@@ -16,9 +16,10 @@ struct SurahRow: View {
             }
             Spacer()
             Image(systemName: "chevron.right")
-                .foregroundColor(Color.accentBrand)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color.kuraniAccentLight)
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, 4)
         .contentShape(Rectangle())
     }
 }


### PR DESCRIPTION
## Summary
- adopt a new Apple-inspired color palette and gradient-driven theme utilities with reusable card and button styles
- restyle the library, notes, settings, and reader views to use glassmorphism cards, accent tints, and soft shadows across the app
- refresh authentication and note editing surfaces with the updated palette, gradients, and interactive styling for inputs and actions

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6261360f083319cddf5393192f965