### PR TITLE
Fix magic link handler scope and simplify note banner formatting

### DIFF
--- a/Views/Components/SignInPromptView.swift
+++ b/Views/Components/SignInPromptView.swift
@@ -82,7 +82,6 @@ struct SignInPromptView: View {
         }
         .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
     }
-}
 
     @MainActor
     private func sendMagicLink() async {

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -58,10 +58,16 @@ struct ReaderView: View {
                             }
 
                             if let note = viewModel.note(for: ayah) {
+                                let formattedDate = noteFormatter.string(from: note.updatedAt)
+                                let bannerText = String(
+                                    format: NSLocalizedString("reader.noteBanner", comment: "banner"),
+                                    formattedDate
+                                )
+
                                 HStack {
                                     Image(systemName: "pencil.and.outline")
                                         .foregroundStyle(Color.kuraniAccentLight)
-                                    Text(String(format: NSLocalizedString("reader.noteBanner", comment: "banner"), noteFormatter.string(from: note.updatedAt)))
+                                    Text(bannerText)
                                         .font(.system(.caption, design: .rounded))
                                         .foregroundColor(.kuraniTextSecondary)
                                 }


### PR DESCRIPTION
## Summary
- keep the magic link helper inside `SignInPromptView` so its state and environment properties stay in scope
- simplify the reader note banner formatting to avoid a hard-to-type-check expression

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d62a98ac248331a9de1925edd2a17c