### PR TITLE
Remove authentication requirement for notes and add local storage fallback

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -13,7 +13,7 @@ struct KuraniApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView(translationStore: translationStore, notesStore: notesStore, authManager: authManager)
+            RootView(translationStore: translationStore, notesStore: notesStore)
                 .environmentObject(translationStore)
                 .environmentObject(notesStore)
                 .environmentObject(authManager)

--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -39,6 +39,7 @@
 "settings.signin" = "Hyr në llogari";
 "settings.signout" = "Dil nga llogaria";
 "settings.account" = "Llogaria";
+"settings.account.offline" = "Hyrja është çaktivizuar përkohësisht. Shënimet do të ruhen vetëm në këtë pajisje.";
 "settings.translation" = "Përkthimi (shqip)";
 "settings.import" = "Importo përkthimin";
 "settings.import.success" = "Përkthimi u importua";

--- a/Supabase/NotesStore.swift
+++ b/Supabase/NotesStore.swift
@@ -19,16 +19,20 @@ final class NotesStore: ObservableObject {
 
     private let client: SupabaseClient
     private var currentUserId: UUID?
+    private let localStorage = LocalNotesStorage()
+    private let localUserId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
 
     init(client: SupabaseClient) {
         self.client = client
+        notes = localStorage.load()
     }
 
     func observeAuthChanges(authManager: AuthManager) async {
         for await userId in authManager.$userId.values {
             currentUserId = userId
             if userId == nil {
-                notes = []
+                notes = localStorage.load()
+                isLoading = false
             } else {
                 await fetchAll()
             }
@@ -36,7 +40,11 @@ final class NotesStore: ObservableObject {
     }
 
     func fetchAll() async {
-        guard let userId = currentUserId else { return }
+        guard let userId = currentUserId else {
+            isLoading = false
+            notes = localStorage.load()
+            return
+        }
         isLoading = true
         defer { isLoading = false }
         do {
@@ -61,24 +69,73 @@ final class NotesStore: ObservableObject {
     }
 
     func upsertNote(surah: Int, ayah: Int, text: String) async throws {
-        guard let userId = currentUserId else { throw NotesError.unauthenticated }
-        let payload = NoteInsert(user_id: userId.uuidString, surah: surah, ayah: ayah, text: text)
-        let response: PostgrestResponse<[NoteDTO]> = try await client.from("notes")
-            .upsert([payload], onConflict: "user_id,surah,ayah")
-            .select()
-            .execute()
-        if let dto = response.value.first?.note {
-            if let index = notes.firstIndex(where: { $0.surah == dto.surah && $0.ayah == dto.ayah }) {
-                notes[index] = dto
-            } else {
-                notes.append(dto)
-                notes.sort { lhs, rhs in
-                    if lhs.surah == rhs.surah {
-                        return lhs.ayah < rhs.ayah
+        if let userId = currentUserId {
+            let payload = NoteInsert(user_id: userId.uuidString, surah: surah, ayah: ayah, text: text)
+            let response: PostgrestResponse<[NoteDTO]> = try await client.from("notes")
+                .upsert([payload], onConflict: "user_id,surah,ayah")
+                .select()
+                .execute()
+            if let dto = response.value.first?.note {
+                if let index = notes.firstIndex(where: { $0.surah == dto.surah && $0.ayah == dto.ayah }) {
+                    notes[index] = dto
+                } else {
+                    notes.append(dto)
+                    notes.sort { lhs, rhs in
+                        if lhs.surah == rhs.surah {
+                            return lhs.ayah < rhs.ayah
+                        }
+                        return lhs.surah < rhs.surah
                     }
-                    return lhs.surah < rhs.surah
                 }
             }
+            return
+        }
+
+        let now = Date()
+        if let index = notes.firstIndex(where: { $0.surah == surah && $0.ayah == ayah }) {
+            var updatedNote = notes[index]
+            updatedNote.text = text
+            updatedNote.updatedAt = now
+            notes[index] = updatedNote
+        } else {
+            let note = Note(userId: localUserId, surah: surah, ayah: ayah, text: text, updatedAt: now)
+            notes.append(note)
+        }
+
+        notes.sort { lhs, rhs in
+            if lhs.surah == rhs.surah {
+                return lhs.ayah < rhs.ayah
+            }
+            return lhs.surah < rhs.surah
+        }
+
+        localStorage.save(notes)
+    }
+}
+
+private struct LocalNotesStorage {
+    private let fileURL: URL = {
+        let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return directory.appendingPathComponent("local-notes.json")
+    }()
+
+    func load() -> [Note] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        do {
+            return try JSONDecoder().decode([Note].self, from: data)
+        } catch {
+            print("Failed to decode local notes", error)
+            return []
+        }
+    }
+
+    func save(_ notes: [Note]) {
+        do {
+            let data = try JSONEncoder().encode(notes)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            print("Failed to save local notes", error)
         }
     }
 }

--- a/ViewModels/SettingsViewModel.swift
+++ b/ViewModels/SettingsViewModel.swift
@@ -7,19 +7,13 @@ final class SettingsViewModel: ObservableObject {
     @Published var isImporting: Bool = false
 
     private let translationStore: TranslationStore
-    private let authManager: AuthManager
 
-    init(translationStore: TranslationStore, authManager: AuthManager) {
+    init(translationStore: TranslationStore) {
         self.translationStore = translationStore
-        self.authManager = authManager
     }
 
     var isUsingSampleTranslation: Bool {
         translationStore.isUsingSample
-    }
-
-    var isSignedIn: Bool {
-        authManager.userId != nil
     }
 
     func importTranslation(from url: URL) async {
@@ -31,14 +25,5 @@ final class SettingsViewModel: ObservableObject {
             toast = LocalizedStringKey("settings.import.invalid")
         }
         isImporting = false
-    }
-
-    func signOut() async {
-        await authManager.signOut()
-    }
-
-    func sendMagicLink(email: String) async {
-        await authManager.sendMagicLink(to: email)
-        toast = LocalizedStringKey("signin.email.sent")
     }
 }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -6,7 +6,7 @@ struct ContentView: View {
     @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.shared.client)
 
     var body: some View {
-        RootView(translationStore: translationStore, notesStore: notesStore, authManager: authManager)
+        RootView(translationStore: translationStore, notesStore: notesStore)
             .environmentObject(translationStore)
             .environmentObject(notesStore)
             .environmentObject(authManager)

--- a/Views/LibraryView.swift
+++ b/Views/LibraryView.swift
@@ -11,7 +11,6 @@ struct LibraryView: View {
 
     @EnvironmentObject private var translationStore: TranslationStore
     @EnvironmentObject private var notesStore: NotesStore
-    @EnvironmentObject private var authManager: AuthManager
 
     @State private var path: [ReaderRoute] = []
 
@@ -88,7 +87,6 @@ struct LibraryView: View {
                     startingAyah: route.ayah,
                     openNotesTab: openNotesTab
                 )
-                .environmentObject(authManager)
             }
             .onAppear {
                 viewModel.refreshLastRead()

--- a/Views/NotesView.swift
+++ b/Views/NotesView.swift
@@ -10,29 +10,13 @@ struct NotesView: View {
     let translationStore: TranslationStore
 
     @EnvironmentObject private var notesStore: NotesStore
-    @EnvironmentObject private var authManager: AuthManager
 
     @State private var path: [ReaderRoute] = []
-    @State private var showingSignInSheet = false
 
     var body: some View {
         NavigationStack(path: $path) {
             Group {
-                if authManager.userId == nil {
-                    VStack(spacing: 24) {
-                        BrandHeader(titleKey: "notes.title", subtitle: "notes.signinRequired")
-                            .padding(.horizontal, 16)
-                        Button {
-                            showingSignInSheet = true
-                        } label: {
-                            Text(LocalizedStringKey("action.signin"))
-                                .frame(maxWidth: 200)
-                        }
-                        .buttonStyle(GradientButtonStyle())
-                        Spacer()
-                    }
-                    .padding()
-                } else if notesStore.isLoading {
+                if notesStore.isLoading {
                     VStack(spacing: 16) {
                         ProgressView(LocalizedStringKey("notes.loading"))
                             .progressViewStyle(.circular)
@@ -91,17 +75,12 @@ struct NotesView: View {
             }
             .background(KuraniTheme.backgroundGradient.ignoresSafeArea())
             .navigationTitle(LocalizedStringKey("notes.title"))
-            .sheet(isPresented: $showingSignInSheet) {
-                SignInPromptView()
-                    .environmentObject(authManager)
-            }
             .navigationDestination(for: ReaderRoute.self) { route in
                 ReaderView(
                     viewModel: ReaderViewModel(surahNumber: route.surah, translationStore: translationStore, notesStore: notesStore),
                     startingAyah: route.ayah,
                     openNotesTab: { path = [] }
                 )
-                .environmentObject(authManager)
             }
         }
         .background(KuraniTheme.backgroundGradient.ignoresSafeArea())

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -6,13 +6,10 @@ struct ReaderView: View {
     let startingAyah: Int?
     let openNotesTab: () -> Void
 
-    @EnvironmentObject private var authManager: AuthManager
-
     @State private var selectedAyahForActions: Ayah?
     @State private var showingActions = false
     @State private var shareText: String = ""
     @State private var showingShareSheet = false
-    @State private var showingSignInSheet = false
     @State private var showToast = false
 
     private let noteFormatter: DateFormatter = {
@@ -122,11 +119,7 @@ struct ReaderView: View {
                     }
                     .accessibilityLabel(LocalizedStringKey("reader.lineSpacing"))
                     Button {
-                        if authManager.userId == nil {
-                            showingSignInSheet = true
-                        } else {
-                            openNotesTab()
-                        }
+                        openNotesTab()
                     } label: {
                         Image(systemName: "note.text")
                             .foregroundStyle(Color.kuraniAccentLight)
@@ -163,10 +156,6 @@ struct ReaderView: View {
         .sheet(isPresented: $showingShareSheet) {
             ShareSheet(items: [shareText])
         }
-        .sheet(isPresented: $showingSignInSheet) {
-            SignInPromptView()
-                .environmentObject(authManager)
-        }
         .confirmationDialog(LocalizedStringKey("action.edit"), isPresented: $showingActions, presenting: selectedAyahForActions) { ayah in
             Button(LocalizedStringKey("action.copy")) { copyAyah(ayah) }
             Button(LocalizedStringKey("action.share")) { shareAyah(ayah) }
@@ -191,10 +180,6 @@ struct ReaderView: View {
     }
 
     private func openNoteEditor(for ayah: Ayah) {
-        guard authManager.userId != nil else {
-            showingSignInSheet = true
-            return
-        }
         viewModel.openNoteEditor(for: ayah)
     }
 

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -5,7 +5,6 @@ struct RootView: View {
 
     @ObservedObject var translationStore: TranslationStore
     @ObservedObject var notesStore: NotesStore
-    @ObservedObject var authManager: AuthManager
 
     @StateObject private var libraryViewModel: LibraryViewModel
     @StateObject private var notesViewModel: NotesViewModel
@@ -13,13 +12,12 @@ struct RootView: View {
 
     @State private var selectedTab: Tab = .library
 
-    init(translationStore: TranslationStore, notesStore: NotesStore, authManager: AuthManager) {
+    init(translationStore: TranslationStore, notesStore: NotesStore) {
         self.translationStore = translationStore
         self.notesStore = notesStore
-        self.authManager = authManager
         _libraryViewModel = StateObject(wrappedValue: LibraryViewModel(translationStore: translationStore))
         _notesViewModel = StateObject(wrappedValue: NotesViewModel(notesStore: notesStore))
-        _settingsViewModel = StateObject(wrappedValue: SettingsViewModel(translationStore: translationStore, authManager: authManager))
+        _settingsViewModel = StateObject(wrappedValue: SettingsViewModel(translationStore: translationStore))
     }
 
     var body: some View {
@@ -41,7 +39,6 @@ struct RootView: View {
             .tag(Tab.notes)
 
             SettingsView(viewModel: settingsViewModel)
-                .environmentObject(authManager)
                 .background(Color.clear)
             .tabItem {
                 Label(LocalizedStringKey("tabs.settings"), systemImage: "gearshape")

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -2,10 +2,8 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var viewModel: SettingsViewModel
-    @EnvironmentObject private var authManager: AuthManager
 
     @State private var showingImporter = false
-    @State private var showingSignInSheet = false
     @State private var toastVisible = false
 
     var body: some View {
@@ -13,30 +11,8 @@ struct SettingsView: View {
             Form {
                 Section(header: Text(LocalizedStringKey("settings.account"))) {
                     VStack(alignment: .leading, spacing: 16) {
-                        if let user = authManager.user {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(user.email ?? "")
-                                    .foregroundColor(.kuraniTextPrimary)
-                                Text(user.id.uuidString)
-                                    .font(.system(.caption, design: .monospaced))
-                                    .foregroundColor(.kuraniTextSecondary)
-                            }
-                        } else {
-                            Text(LocalizedStringKey("notes.signinRequired"))
-                                .foregroundColor(.kuraniTextSecondary)
-                        }
-
-                        if authManager.userId == nil {
-                            Button(LocalizedStringKey("settings.signin")) {
-                                showingSignInSheet = true
-                            }
-                            .buttonStyle(GradientButtonStyle())
-                        } else {
-                            Button(LocalizedStringKey("settings.signout")) {
-                                Task { await viewModel.signOut() }
-                            }
-                            .buttonStyle(GradientButtonStyle())
-                        }
+                        Text(LocalizedStringKey("settings.account.offline"))
+                            .foregroundColor(.kuraniTextSecondary)
                     }
                     .appleCard()
                     .padding(.horizontal, 12)
@@ -97,10 +73,6 @@ struct SettingsView: View {
                 case .failure:
                     viewModel.toast = LocalizedStringKey("settings.import.invalid")
                 }
-            }
-            .sheet(isPresented: $showingSignInSheet) {
-                SignInPromptView()
-                    .environmentObject(authManager)
             }
             .overlay(alignment: .bottom) {
                 if toastVisible, let message = viewModel.toast {


### PR DESCRIPTION
## Summary
- remove sign-in prompts from the notes, reader, and settings flows so features remain accessible
- add a local JSON-backed storage path for notes when no authenticated user is present
- update root wiring and copy to reflect the temporary offline-only notes experience

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d63806804883319b46907fa1a96e98