### PR TITLE
Adjust theme to red orange palette

### DIFF
--- a/App/Theme.swift
+++ b/App/Theme.swift
@@ -45,7 +45,7 @@ struct BrandHeader: View {
                 .fill(Color.kuraniAccentLight.opacity(0.22))
                 .overlay(
                     RoundedRectangle(cornerRadius: 30, style: .continuous)
-                        .stroke(Color.kuraniAccentBrand.opacity(0.28), lineWidth: 1.2)
+                        .stroke(Color.white.opacity(0.6), lineWidth: 1.2)
                 )
                 .shadow(color: Color.kuraniPrimaryBrand.opacity(0.14), radius: 18, y: 12)
         )
@@ -69,7 +69,7 @@ struct Pill: View {
             )
             .overlay(
                 Capsule()
-                    .stroke(Color.kuraniAccentBrand.opacity(0.25), lineWidth: 0.8)
+                    .stroke(Color.white.opacity(0.6), lineWidth: 0.8)
             )
             .shadow(color: Color.kuraniAccentBrand.opacity(0.18), radius: 8, y: 4)
     }
@@ -86,7 +86,7 @@ struct GradientButtonStyle: ButtonStyle {
                     .fill(KuraniTheme.accent)
                     .overlay(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(Color.kuraniAccentLight.opacity(0.4), lineWidth: 1)
+                            .stroke(Color.white.opacity(0.7), lineWidth: 1)
                     )
             )
             .shadow(color: Color.kuraniAccentBrand.opacity(configuration.isPressed ? 0.12 : 0.22), radius: 12, y: 8)
@@ -124,7 +124,7 @@ private struct AppleCardBackground: ViewModifier {
                     .fill(Color.kuraniPrimarySurface)
                     .overlay(
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .stroke(Color.kuraniPrimaryBrand.opacity(0.08), lineWidth: 1)
+                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
                     )
                     .shadow(color: Color.kuraniPrimaryBrand.opacity(0.08), radius: 10, y: 6)
             )

--- a/Resources/Assets.xcassets/Accent Color.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.718",
-          "green" : "0.478",
-          "blue" : "0.239"
+          "red" : "1.000",
+          "green" : "0.341",
+          "blue" : "0.133"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/Accent.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.718",
-          "green" : "0.478",
-          "blue" : "0.239"
+          "red" : "1.000",
+          "green" : "0.341",
+          "blue" : "0.133"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
+++ b/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.898",
-          "green" : "0.725",
-          "blue" : "0.478"
+          "red" : "1.000",
+          "green" : "0.671",
+          "blue" : "0.569"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
+++ b/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.961",
-          "green" : "0.945",
-          "blue" : "0.902"
+          "red" : "1.000",
+          "green" : "0.953",
+          "blue" : "0.878"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/Primary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Primary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.294",
-          "green" : "0.247",
-          "blue" : "0.192"
+          "red" : "1.000",
+          "green" : "0.435",
+          "blue" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
+++ b/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.996",
-          "green" : "0.988",
-          "blue" : "0.969"
+          "red" : "1.000",
+          "green" : "0.878",
+          "blue" : "0.698"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/TextPrimary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/TextPrimary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.180",
-          "green" : "0.165",
-          "blue" : "0.145"
+          "red" : "0.000",
+          "green" : "0.000",
+          "blue" : "0.000"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.522",
-          "green" : "0.463",
-          "blue" : "0.412"
+          "red" : "0.000",
+          "green" : "0.000",
+          "blue" : "0.000"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## Summary
- retint the shared color assets to a red-orange scheme with black typography
- update SwiftUI border strokes to render with white to match the new palette

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d6734a75d083319e6d7248ec0805a8