### PR TITLE
Apply new brand palette with light theme

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -7,8 +7,9 @@ struct KuraniApp: App {
     @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.shared.client)
 
     init() {
-        UINavigationBar.appearance().largeTitleTextAttributes = [.foregroundColor: UIColor.white]
-        UINavigationBar.appearance().titleTextAttributes = [.foregroundColor: UIColor.white]
+        let navigationBarAppearance = UINavigationBar.appearance()
+        navigationBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.black]
+        navigationBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.black]
     }
 
     var body: some Scene {
@@ -17,7 +18,7 @@ struct KuraniApp: App {
                 .environmentObject(translationStore)
                 .environmentObject(notesStore)
                 .environmentObject(authManager)
-                .preferredColorScheme(.dark)
+                .preferredColorScheme(.light)
                 .task {
                     await translationStore.loadInitialData()
                     await notesStore.observeAuthChanges(authManager: authManager)

--- a/App/Theme.swift
+++ b/App/Theme.swift
@@ -45,7 +45,7 @@ struct BrandHeader: View {
                 .fill(Color.kuraniAccentLight.opacity(0.22))
                 .overlay(
                     RoundedRectangle(cornerRadius: 30, style: .continuous)
-                        .stroke(Color.white.opacity(0.6), lineWidth: 1.2)
+                        .stroke(Color.black.opacity(0.08), lineWidth: 1.2)
                 )
                 .shadow(color: Color.kuraniPrimaryBrand.opacity(0.14), radius: 18, y: 12)
         )
@@ -69,7 +69,7 @@ struct Pill: View {
             )
             .overlay(
                 Capsule()
-                    .stroke(Color.white.opacity(0.6), lineWidth: 0.8)
+                    .stroke(Color.black.opacity(0.12), lineWidth: 0.8)
             )
             .shadow(color: Color.kuraniAccentBrand.opacity(0.18), radius: 8, y: 4)
     }
@@ -86,7 +86,7 @@ struct GradientButtonStyle: ButtonStyle {
                     .fill(KuraniTheme.accent)
                     .overlay(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(Color.white.opacity(0.7), lineWidth: 1)
+                            .stroke(Color.black.opacity(0.15), lineWidth: 1)
                     )
             )
             .shadow(color: Color.kuraniAccentBrand.opacity(configuration.isPressed ? 0.12 : 0.22), radius: 12, y: 8)
@@ -124,7 +124,7 @@ private struct AppleCardBackground: ViewModifier {
                     .fill(Color.kuraniPrimarySurface)
                     .overlay(
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                            .stroke(Color.black.opacity(0.08), lineWidth: 1)
                     )
                     .shadow(color: Color.kuraniPrimaryBrand.opacity(0.08), radius: 10, y: 6)
             )

--- a/Resources/Assets.xcassets/Accent.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "1.000",
-          "green" : "0.341",
-          "blue" : "0.133"
+          "red" : "0.000",
+          "green" : "0.482",
+          "blue" : "0.655"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
+++ b/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "1.000",
-          "green" : "0.671",
-          "blue" : "0.569"
+          "red" : "0.263",
+          "green" : "0.702",
+          "blue" : "0.682"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
+++ b/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "red" : "1.000",
-          "green" : "0.953",
-          "blue" : "0.878"
+          "green" : "1.000",
+          "blue" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/Primary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Primary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "1.000",
-          "green" : "0.435",
-          "blue" : "0.000"
+          "red" : "0.867",
+          "green" : "0.192",
+          "blue" : "0.384"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
+++ b/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "1.000",
-          "green" : "0.878",
-          "blue" : "0.698"
+          "red" : "0.588",
+          "green" : "0.482",
+          "blue" : "0.714"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "red" : "0.000",
-          "green" : "0.000",
-          "blue" : "0.000"
+          "green" : "0.482",
+          "blue" : "0.655"
         }
       },
       "idiom" : "universal"

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
             .environmentObject(translationStore)
             .environmentObject(notesStore)
             .environmentObject(authManager)
-            .preferredColorScheme(.dark)
+            .preferredColorScheme(.light)
             .task {
                 await translationStore.loadInitialData()
                 await notesStore.observeAuthChanges(authManager: authManager)

--- a/Views/NoteEditorView.swift
+++ b/Views/NoteEditorView.swift
@@ -26,7 +26,7 @@ struct NoteEditorView: View {
                             .fill(Color.kuraniPrimarySurface.opacity(0.58))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 26, style: .continuous)
-                                    .stroke(Color.white.opacity(0.12), lineWidth: 0.8)
+                                    .stroke(Color.black.opacity(0.12), lineWidth: 0.8)
                             )
                             .shadow(color: Color.black.opacity(0.32), radius: 20, y: 14)
                     )

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -92,7 +92,7 @@ main
                                         .fill(Color.kuraniPrimarySurface.opacity(0.68))
                                         .overlay(
                                             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                                                .stroke(Color.white.opacity(0.12), lineWidth: 0.6)
+                                                .stroke(Color.black.opacity(0.12), lineWidth: 0.6)
                                         )
                                 )
                             }


### PR DESCRIPTION
## Summary
- replace the asset catalog colors with the provided palette, including a white background and black primary text
- switch the app to the light color scheme and update navigation bar styling to use dark titles
- refresh component strokes to use subtle dark outlines that fit the new palette

## Testing
- not run (platform-specific)


------
https://chatgpt.com/codex/tasks/task_e_68d675861abc8331b6540cf8460222ea