### PR TITLE
Update app theme colors to teal and white

### DIFF
--- a/Resources/Assets.xcassets/Accent Color.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent Color.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "red" : "1.000",
-          "green" : "0.341",
-          "blue" : "0.133"
+          "green" : "1.000",
+          "blue" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/Accent.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.000",
-          "green" : "0.482",
-          "blue" : "0.655"
+          "red" : "1.000",
+          "green" : "1.000",
+          "blue" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
+++ b/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "red" : "0.263",
-          "green" : "0.702",
-          "blue" : "0.682"
+          "alpha" : "0.600",
+          "red" : "1.000",
+          "green" : "1.000",
+          "blue" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
+++ b/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "1.000",
-          "green" : "1.000",
-          "blue" : "1.000"
+          "red" : "0.008",
+          "green" : "0.463",
+          "blue" : "0.435"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/Primary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Primary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.867",
-          "green" : "0.192",
-          "blue" : "0.384"
+          "red" : "0.027",
+          "green" : "0.071",
+          "blue" : "0.051"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
+++ b/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.588",
-          "green" : "0.482",
-          "blue" : "0.714"
+          "red" : "0.012",
+          "green" : "0.380",
+          "blue" : "0.357"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/TextPrimary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/TextPrimary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.000",
-          "green" : "0.000",
-          "blue" : "0.000"
+          "red" : "1.000",
+          "green" : "1.000",
+          "blue" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
+++ b/Resources/Assets.xcassets/TextSecondary.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "red" : "0.000",
-          "green" : "0.482",
-          "blue" : "0.655"
+          "alpha" : "0.750",
+          "red" : "1.000",
+          "green" : "1.000",
+          "blue" : "1.000"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## Summary
- update the shared color assets to use the new teal primary palette and dark border hue
- switch accent and text colors to solid white so UI text aligns with the requested theme

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d67988f1588331adfbfc621470ba4c