### PR TITLE
Guard haptics on unsupported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Për të ngarkuar një përkthim të plotë, përdor `Importo përkthimin` në c
 2. Sigurohu që skedarët `QuranMeta.json`, `sample_translation.json`, `Assets.xcassets` dhe `Config.xcconfig` janë pjesë e target-it.
 3. Ndërto dhe ekzekuto aplikacionin në simulator ose pajisje me iOS 17.
 
+## Zgjidhja e problemeve
+
+### Gabim: `hapticpatternlibrary.plist` couldn't be opened
+
+- Ky log shfaqet kur aplikacioni ekzekutohet në macOS ose në simulatorë pa motor haptik të disponueshëm.
+- Gabimi nuk ndikon në funksionimin e aplikacionit; versioni aktual kontrollon automatikisht nëse pajisja mbështet haptikë dhe nuk tenton të prodhojë feedback kur mungon.
+- Për të testuar feedback-un haptik, përdor një pajisje iOS me motor Taptic.
+
 ## Sjellja e shënimeve
 - Çdo përdorues mund të ruajë **një** shënim për çdo kombinim (sure, ajet).
 - Ruajtja përdor `upsert` në Supabase dhe nuk ekziston asnjë veprim për fshirje.

--- a/Utils/Haptics.swift
+++ b/Utils/Haptics.swift
@@ -1,12 +1,30 @@
 import Foundation
 import UIKit
+#if canImport(CoreHaptics)
+import CoreHaptics
+#endif
 
 enum Haptics {
+    private static let supportsHaptics: Bool = {
+#if targetEnvironment(macCatalyst)
+        return false
+#else
+#if canImport(CoreHaptics)
+        if #available(iOS 13.0, *) {
+            return CHHapticEngine.capabilitiesForHardware().supportsHaptics
+        }
+#endif
+        return false
+#endif
+    }()
+
     static func success() {
+        guard supportsHaptics else { return }
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
     }
 
     static func warning() {
+        guard supportsHaptics else { return }
         UINotificationFeedbackGenerator().notificationOccurred(.warning)
     }
 }


### PR DESCRIPTION
## Summary
- avoid triggering UIKit feedback generators when haptics hardware is unavailable to stop CHHapticPattern errors
- document the harmless `hapticpatternlibrary.plist` log in the README troubleshooting section

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d67ba2e6cc8331a98f8ffaea4fd307