### PR TITLE
Make ayah pill number and border black

### DIFF
--- a/App/Theme.swift
+++ b/App/Theme.swift
@@ -62,14 +62,14 @@ struct Pill: View {
             .fontWeight(.semibold)
             .padding(.vertical, 6)
             .padding(.horizontal, 12)
-            .foregroundColor(.kuraniTextPrimary)
+            .foregroundColor(.black)
             .background(
                 Capsule()
                     .fill(Color.kuraniAccentLight.opacity(0.9))
             )
             .overlay(
                 Capsule()
-                    .stroke(Color.black.opacity(0.12), lineWidth: 0.8)
+                    .stroke(Color.black, lineWidth: 0.8)
             )
             .shadow(color: Color.kuraniAccentBrand.opacity(0.18), radius: 8, y: 4)
     }


### PR DESCRIPTION
## Summary
- update the reader pill styling so the ayah number text renders in black
- apply a solid black stroke to the pill background for the ayah number

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d67ddd4cfc8331b4a5fca208c357a7