### PR TITLE
Ensure note editor text appears black

### DIFF
--- a/Views/NoteEditorView.swift
+++ b/Views/NoteEditorView.swift
@@ -30,7 +30,7 @@ struct NoteEditorView: View {
                             )
                             .shadow(color: Color.black.opacity(0.32), radius: 20, y: 14)
                     )
-                    .foregroundColor(.kuraniTextPrimary)
+                    .foregroundColor(.black)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 24)


### PR DESCRIPTION
## Summary
- update the note editor text color so typing appears in black

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67e4bf8208331bb46ab89183f6a07