### PR TITLE
Add fullscreen reading mode toggle and Arabic-specific icon

### DIFF
--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "reader.textSize" = "Madhësia e tekstit";
 "reader.lineSpacing" = "Hapësira ndër rreshta";
 "reader.toggleArabic" = "Shfaq tekstin arab";
+"reader.toggleChrome" = "Fsheh panelet";
 "reader.progress" = "%ld / %ld";
 "reader.note.add" = "Shkruaj shënim";
 "reader.note.edit" = "Ndrysho shënimin";


### PR DESCRIPTION
## Summary
- add a full screen reading toggle that hides navigation and tab chrome while reading, including an overlay to restore controls
- update the Arabic text toggle to use a custom icon featuring the Arabic letter ع for clearer affordance
- add localization for the new reading mode toggle label

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d67db320848331b21ed9234e0a396f