### PR TITLE
Add Arabic dictionary lookup to reader

### DIFF
--- a/Data/ArabicDictionary.json
+++ b/Data/ArabicDictionary.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "allah",
+    "word": "اللّٰهُ",
+    "transliteration": "Allahu",
+    "meanings": [
+      "Zoti", 
+      "I Vetmi që meriton adhurim" 
+    ],
+    "notes": "Forma e shquar e fjalës Allah, emri më i lartë i Zotit."
+  },
+  {
+    "id": "rahman",
+    "word": "الرَّحْمَٰنِ",
+    "transliteration": "Er-Rahmân",
+    "meanings": [
+      "Mëshiruesi", 
+      "Ai që tregon mëshirë të plotë për të gjitha krijesat" 
+    ],
+    "notes": "Një nga emrat e Zotit që tregon mëshirën gjithëpërfshirëse."
+  },
+  {
+    "id": "rahim",
+    "word": "الرَّحِيمِ",
+    "transliteration": "Er-Rahîm",
+    "meanings": [
+      "Mëshirëploti", 
+      "Ai që jep mëshirë të veçantë për besimtarët" 
+    ],
+    "notes": "Emër hyjnor që tregon mëshirën e vazhdueshme për besimtarët."
+  },
+  {
+    "id": "alhamdu",
+    "word": "ٱلْحَمْدُ",
+    "transliteration": "El-hamdu",
+    "meanings": [
+      "Lavdi", 
+      "Falënderim i plotë"
+    ],
+    "notes": "Përdoret për të shprehur lavdërim dhe falënderim të plotë ndaj Zotit."
+  },
+  {
+    "id": "rabb",
+    "word": "رَبِّ",
+    "transliteration": "Rabbi",
+    "meanings": [
+      "Zoti", 
+      "Krijuesi dhe mirëmbajtësi"
+    ],
+    "notes": "Term që tregon kujdesin dhe sundimin hyjnor mbi gjithçka."
+  }
+]

--- a/Kurani.xcodeproj/project.pbxproj
+++ b/Kurani.xcodeproj/project.pbxproj
@@ -40,6 +40,11 @@ D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */ = {isa = PBXBuil
 D47AD4DA2A6B02A300000059 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = D47AD4DA2A6B02A30000005B /* Supabase */; };
 D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D4FA5A8D2B12345600000060 /* LaunchScreen.storyboard */; };
 D4F6B6C22C9F000100000081 /* ArabicText.json in Resources */ = {isa = PBXBuildFile; fileRef = D4F6B6C12C9F000100000080 /* ArabicText.json */; };
+D4F6B6D02C9F000100000090 /* ArabicDictionaryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6D12C9F000100000091 /* ArabicDictionaryEntry.swift */; };
+D4F6B6D22C9F000100000092 /* ArabicDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6D32C9F000100000093 /* ArabicDictionary.swift */; };
+D4F6B6D42C9F000100000094 /* ArabicSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6D52C9F000100000095 /* ArabicSelectableTextView.swift */; };
+D4F6B6D62C9F000100000096 /* ArabicDictionaryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6D72C9F000100000097 /* ArabicDictionaryDetailView.swift */; };
+D4F6B6D82C9F000100000098 /* ArabicDictionary.json in Resources */ = {isa = PBXBuildFile; fileRef = D4F6B6D92C9F000100000099 /* ArabicDictionary.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,7 +61,12 @@ D47AD4DA2A6B02A300000022 /* Ayah.swift */ = {isa = PBXFileReference; lastKnownFi
 D47AD4DA2A6B02A300000023 /* Surah.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Surah.swift; sourceTree = "<group>"; };
 D47AD4DA2A6B02A300000024 /* Note.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Note.swift; sourceTree = "<group>"; };
 D4F6B6C12C9F000100000080 /* ArabicText.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ArabicText.json; sourceTree = "<group>"; };
-		D47AD4DA2A6B02A300000025 /* NotesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesStore.swift; sourceTree = "<group>"; };
+D4F6B6D12C9F000100000091 /* ArabicDictionaryEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArabicDictionaryEntry.swift; sourceTree = "<group>"; };
+D4F6B6D32C9F000100000093 /* ArabicDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArabicDictionary.swift; sourceTree = "<group>"; };
+D4F6B6D52C9F000100000095 /* ArabicSelectableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArabicSelectableTextView.swift; sourceTree = "<group>"; };
+D4F6B6D72C9F000100000097 /* ArabicDictionaryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArabicDictionaryDetailView.swift; sourceTree = "<group>"; };
+D4F6B6D92C9F000100000099 /* ArabicDictionary.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ArabicDictionary.json; sourceTree = "<group>"; };
+                D47AD4DA2A6B02A300000025 /* NotesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesStore.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A300000026 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A300000027 /* SupabaseClientProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClientProvider.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A300000028 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
@@ -118,16 +128,17 @@ D4F6B6C12C9F000100000080 /* ArabicText.json */ = {isa = PBXFileReference; lastKn
 			path = App;
 			sourceTree = "<group>";
 		};
-		D47AD4DA2A6B02A30000000E /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				D47AD4DA2A6B02A300000022 /* Ayah.swift */,
-				D47AD4DA2A6B02A300000023 /* Surah.swift */,
-				D47AD4DA2A6B02A300000024 /* Note.swift */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
+                D47AD4DA2A6B02A30000000E /* Models */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D47AD4DA2A6B02A300000022 /* Ayah.swift */,
+                                D47AD4DA2A6B02A300000023 /* Surah.swift */,
+                                D47AD4DA2A6B02A300000024 /* Note.swift */,
+                                D4F6B6D12C9F000100000091 /* ArabicDictionaryEntry.swift */,
+                        );
+                        path = Models;
+                        sourceTree = "<group>";
+                };
 		D47AD4DA2A6B02A30000000F /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -144,14 +155,16 @@ D4F6B6C12C9F000100000080 /* ArabicText.json */ = {isa = PBXFileReference; lastKn
 			path = Views;
 			sourceTree = "<group>";
 		};
-		D47AD4DA2A6B02A300000010 /* Components */ = {
-			isa = PBXGroup;
-			children = (
-				D47AD4DA2A6B02A300000038 /* SignInPromptView.swift */,
-			);
-			path = Components;
-			sourceTree = "<group>";
-		};
+                D47AD4DA2A6B02A300000010 /* Components */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D4F6B6D52C9F000100000095 /* ArabicSelectableTextView.swift */,
+                                D4F6B6D72C9F000100000097 /* ArabicDictionaryDetailView.swift */,
+                                D47AD4DA2A6B02A300000038 /* SignInPromptView.swift */,
+                        );
+                        path = Components;
+                        sourceTree = "<group>";
+                };
 		D47AD4DA2A6B02A300000011 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -163,17 +176,18 @@ D4F6B6C12C9F000100000080 /* ArabicText.json */ = {isa = PBXFileReference; lastKn
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
-		D47AD4DA2A6B02A300000012 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-				D47AD4DA2A6B02A300000028 /* ShareSheet.swift */,
-				D47AD4DA2A6B02A300000029 /* FileIO.swift */,
-				D47AD4DA2A6B02A30000002A /* Haptics.swift */,
-				D47AD4DA2A6B02A30000002B /* AppStorageKeys.swift */,
-			);
-			path = Utils;
-			sourceTree = "<group>";
-		};
+                D47AD4DA2A6B02A300000012 /* Utils */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D47AD4DA2A6B02A300000028 /* ShareSheet.swift */,
+                                D47AD4DA2A6B02A300000029 /* FileIO.swift */,
+                                D47AD4DA2A6B02A30000002A /* Haptics.swift */,
+                                D47AD4DA2A6B02A30000002B /* AppStorageKeys.swift */,
+                                D4F6B6D32C9F000100000093 /* ArabicDictionary.swift */,
+                        );
+                        path = Utils;
+                        sourceTree = "<group>";
+                };
 		D47AD4DA2A6B02A300000013 /* Supabase */ = {
 			isa = PBXGroup;
 			children = (
@@ -184,17 +198,18 @@ D4F6B6C12C9F000100000080 /* ArabicText.json */ = {isa = PBXFileReference; lastKn
 			path = Supabase;
 			sourceTree = "<group>";
 		};
-D47AD4DA2A6B02A300000014 /* Data */ = {
-isa = PBXGroup;
-children = (
-D47AD4DA2A6B02A30000001F /* TranslationStore.swift */,
-D47AD4DA2A6B02A300000020 /* QuranMeta.json */,
-D47AD4DA2A6B02A300000021 /* sample_translation.json */,
-D4F6B6C12C9F000100000080 /* ArabicText.json */,
-);
-path = Data;
-sourceTree = "<group>";
-};
+                D47AD4DA2A6B02A300000014 /* Data */ = {
+                        isa = PBXGroup;
+                        children = (
+                                D47AD4DA2A6B02A30000001F /* TranslationStore.swift */,
+                                D47AD4DA2A6B02A300000020 /* QuranMeta.json */,
+                                D47AD4DA2A6B02A300000021 /* sample_translation.json */,
+                                D4F6B6C12C9F000100000080 /* ArabicText.json */,
+                                D4F6B6D92C9F000100000099 /* ArabicDictionary.json */,
+                        );
+                        path = Data;
+                        sourceTree = "<group>";
+                };
 		D47AD4DA2A6B02A300000015 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -272,14 +287,15 @@ sourceTree = "<group>";
 		D47AD4DA2A6B02A30000000B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
-files = (
-D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */,
-D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */,
-D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */,
-D4F6B6C22C9F000100000081 /* ArabicText.json in Resources */,
-D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */,
-D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
-);
+                        files = (
+                                D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */,
+                                D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */,
+                                D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */,
+                                D4F6B6D82C9F000100000098 /* ArabicDictionary.json in Resources */,
+                                D4F6B6C22C9F000100000081 /* ArabicText.json in Resources */,
+                                D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */,
+                                D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
@@ -295,22 +311,26 @@ D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
 				D47AD4DA2A6B02A300000051 /* RootView.swift in Sources */,
 				D47AD4DA2A6B02A300000050 /* NotesView.swift in Sources */,
 				D47AD4DA2A6B02A30000004F /* NoteEditorView.swift in Sources */,
-				D47AD4DA2A6B02A30000004E /* SettingsView.swift in Sources */,
-				D47AD4DA2A6B02A30000004D /* LibraryView.swift in Sources */,
-				D47AD4DA2A6B02A30000004C /* ReaderView.swift in Sources */,
-				D47AD4DA2A6B02A30000004B /* SettingsViewModel.swift in Sources */,
+                                D47AD4DA2A6B02A30000004E /* SettingsView.swift in Sources */,
+                                D47AD4DA2A6B02A30000004D /* LibraryView.swift in Sources */,
+                                D47AD4DA2A6B02A30000004C /* ReaderView.swift in Sources */,
+                                D4F6B6D62C9F000100000096 /* ArabicDictionaryDetailView.swift in Sources */,
+                                D4F6B6D42C9F000100000094 /* ArabicSelectableTextView.swift in Sources */,
+                                D47AD4DA2A6B02A30000004B /* SettingsViewModel.swift in Sources */,
 				D47AD4DA2A6B02A30000004A /* ReaderViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000049 /* NotesViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000048 /* LibraryViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000047 /* AppStorageKeys.swift in Sources */,
 				D47AD4DA2A6B02A300000046 /* Haptics.swift in Sources */,
-				D47AD4DA2A6B02A300000045 /* FileIO.swift in Sources */,
-				D47AD4DA2A6B02A300000044 /* ShareSheet.swift in Sources */,
+                                D47AD4DA2A6B02A300000045 /* FileIO.swift in Sources */,
+                                D4F6B6D22C9F000100000092 /* ArabicDictionary.swift in Sources */,
+                                D47AD4DA2A6B02A300000044 /* ShareSheet.swift in Sources */,
 				D47AD4DA2A6B02A300000043 /* SupabaseClientProvider.swift in Sources */,
 				D47AD4DA2A6B02A300000042 /* AuthManager.swift in Sources */,
-				D47AD4DA2A6B02A300000041 /* NotesStore.swift in Sources */,
-				D47AD4DA2A6B02A300000040 /* Note.swift in Sources */,
-				D47AD4DA2A6B02A30000003F /* Surah.swift in Sources */,
+                                D47AD4DA2A6B02A300000041 /* NotesStore.swift in Sources */,
+                                D47AD4DA2A6B02A300000040 /* Note.swift in Sources */,
+                                D4F6B6D02C9F000100000090 /* ArabicDictionaryEntry.swift in Sources */,
+                                D47AD4DA2A6B02A30000003F /* Surah.swift in Sources */,
 				D47AD4DA2A6B02A30000003E /* Ayah.swift in Sources */,
 				D47AD4DA2A6B02A30000003D /* TranslationStore.swift in Sources */,
 				D47AD4DA2A6B02A30000003C /* Theme.swift in Sources */,

--- a/Models/ArabicDictionaryEntry.swift
+++ b/Models/ArabicDictionaryEntry.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct ArabicDictionaryEntry: Codable, Identifiable, Hashable {
+    let id: String
+    let word: String
+    let transliteration: String
+    let meanings: [String]
+    let notes: String?
+}

--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -76,3 +76,6 @@
 "settings.translation.loaded" = "Përkthimi i ngarkuar";
 "settings.translation.sample" = "Po shfaqet përkthimi i mostrës";
 "reader.jumpLastRead" = "Shko te leximi i fundit";
+"dictionary.notFound" = "Kjo fjalë nuk gjendet ende në fjalor.";
+"dictionary.meanings" = "Kuptimet";
+"dictionary.notes" = "Shënime";

--- a/Utils/ArabicDictionary.swift
+++ b/Utils/ArabicDictionary.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+final class ArabicDictionary {
+    static let shared = ArabicDictionary()
+
+    private var entriesByNormalizedWord: [String: ArabicDictionaryEntry] = [:]
+    private let normalizationSet: CharacterSet
+
+    private init() {
+        var combining = CharacterSet()
+        for value in 0x064B...0x065F {
+            if let scalar = UnicodeScalar(value) {
+                combining.insert(scalar)
+            }
+        }
+        if let daggerAlif = UnicodeScalar(0x0670) {
+            combining.insert(daggerAlif)
+        }
+        for value in 0x06D6...0x06ED {
+            if let scalar = UnicodeScalar(value) {
+                combining.insert(scalar)
+            }
+        }
+        normalizationSet = combining
+        loadEntries()
+    }
+
+    private func loadEntries() {
+        guard let url = Bundle.main.url(forResource: "ArabicDictionary", withExtension: "json") else {
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            let entries = try decoder.decode([ArabicDictionaryEntry].self, from: data)
+            entriesByNormalizedWord = Dictionary(uniqueKeysWithValues: entries.map { entry in
+                let normalized = normalize(entry.word)
+                return (normalized, entry)
+            })
+        } catch {
+            print("Failed to load Arabic dictionary: \(error)")
+        }
+    }
+
+    func lookup(word: String) -> ArabicDictionaryEntry? {
+        let normalized = normalize(word)
+        if let entry = entriesByNormalizedWord[normalized] {
+            return entry
+        }
+
+        // Try trimming common punctuation marks
+        let trimmed = word.trimmingCharacters(in: CharacterSet.punctuationCharacters.union(.whitespacesAndNewlines))
+        if trimmed != word {
+            let trimmedNormalized = normalize(trimmed)
+            return entriesByNormalizedWord[trimmedNormalized]
+        }
+
+        return nil
+    }
+
+    private func normalize(_ word: String) -> String {
+        let noTashkeel = word.unicodeScalars.filter { scalar in
+            !normalizationSet.contains(scalar)
+        }
+        let normalized = String(String.UnicodeScalarView(noTashkeel))
+            .replacingOccurrences(of: "ٱ", with: "ا")
+            .replacingOccurrences(of: "آ", with: "ا")
+            .replacingOccurrences(of: "إ", with: "ا")
+            .replacingOccurrences(of: "أ", with: "ا")
+        return normalized
+    }
+}

--- a/Views/Components/ArabicDictionaryDetailView.swift
+++ b/Views/Components/ArabicDictionaryDetailView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct ArabicDictionaryDetailView: View {
+    let entry: ArabicDictionaryEntry
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(entry.word)
+                        .font(.system(size: 28, weight: .semibold))
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+
+                    Text(entry.transliteration)
+                        .font(.system(size: 16, weight: .medium, design: .rounded))
+                        .foregroundColor(.kuraniTextSecondary)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(LocalizedStringKey("dictionary.meanings"))
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundColor(.kuraniAccentLight)
+
+                    ForEach(entry.meanings, id: \.self) { meaning in
+                        Text("• \(meaning)")
+                            .font(.system(size: 16, design: .rounded))
+                            .foregroundColor(.white)
+                    }
+                }
+
+                if let notes = entry.notes, !notes.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(LocalizedStringKey("dictionary.notes"))
+                            .font(.system(size: 15, weight: .semibold, design: .rounded))
+                            .foregroundColor(.kuraniAccentLight)
+
+                        Text(notes)
+                            .font(.system(size: 16, design: .rounded))
+                            .foregroundColor(.kuraniTextSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(Color.kuraniPrimarySurface)
+    }
+}

--- a/Views/Components/ArabicSelectableTextView.swift
+++ b/Views/Components/ArabicSelectableTextView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import UIKit
+
+struct ArabicSelectableTextView: UIViewRepresentable {
+    let text: String
+    let fontScale: Double
+    let lineSpacingScale: Double
+    let onSelection: (String) -> Void
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.backgroundColor = .clear
+        textView.textAlignment = .right
+        textView.semanticContentAttribute = .forceRightToLeft
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isScrollEnabled = false
+        textView.dataDetectorTypes = []
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.delegate = context.coordinator
+        textView.tintColor = UIColor(Color.kuraniAccentLight)
+        textView.adjustsFontForContentSizeCategory = true
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        updateTextAttributes(for: textView)
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        updateTextAttributes(for: uiView)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    private var fontPointSize: CGFloat {
+        20 * fontScale
+    }
+
+    private func updateTextAttributes(for textView: UITextView) {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .right
+        paragraph.baseWritingDirection = .rightToLeft
+        paragraph.lineSpacing = 4 * lineSpacingScale
+
+        let attributed = NSAttributedString(
+            string: text,
+            attributes: [
+                .paragraphStyle: paragraph,
+                .font: UIFont.systemFont(ofSize: fontPointSize, weight: .regular),
+                .foregroundColor: UIColor.white
+            ]
+        )
+        textView.attributedText = attributed
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        private let parent: ArabicSelectableTextView
+        private var lastSelection: String?
+
+        init(_ parent: ArabicSelectableTextView) {
+            self.parent = parent
+        }
+
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            guard let selectedRange = textView.selectedTextRange else { return }
+            let selectedText = textView.text(in: selectedRange) ?? ""
+            let trimmed = selectedText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                lastSelection = nil
+                return
+            }
+
+            // Avoid repeated callbacks for same selection
+            if trimmed == lastSelection { return }
+            lastSelection = trimmed
+            DispatchQueue.main.async {
+                self.parent.onSelection(trimmed)
+                textView.selectedTextRange = nil
+                self.lastSelection = nil
+            }
+        }
+    }
+}

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -6,19 +6,20 @@ struct ReaderView: View {
     let startingAyah: Int?
     let openNotesTab: () -> Void
 
-codex/update-app-theme-for-reading
+
     @EnvironmentObject private var authManager: AuthManager
     @Environment(\.dismiss) private var dismiss
     @AppStorage(AppStorageKeys.showArabicText) private var showArabicText = false
 
 
-main
     @State private var selectedAyahForActions: Ayah?
     @State private var showingActions = false
     @State private var shareText: String = ""
     @State private var showingShareSheet = false
     @State private var showToast = false
     @State private var isChromeHidden = false
+    @State private var selectedDictionaryEntry: ArabicDictionaryEntry?
+    @State private var pendingDictionaryWord: String?
 
     private let noteFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -63,12 +64,14 @@ main
                                         }
 
                                     if showArabicText, let arabic = ayah.arabicText {
-                                        Text(arabic)
-                                            .font(.system(size: 20 * viewModel.fontScale, weight: .regular))
-                                            .foregroundColor(.white)
-                                            .multilineTextAlignment(.trailing)
-                                            .frame(maxWidth: .infinity, alignment: .trailing)
-                                            .lineSpacing(4 * viewModel.lineSpacingScale)
+                                        ArabicSelectableTextView(
+                                            text: arabic,
+                                            fontScale: viewModel.fontScale,
+                                            lineSpacingScale: viewModel.lineSpacingScale,
+                                            onSelection: handleDictionarySelection
+                                        )
+                                        .frame(maxWidth: .infinity, alignment: .trailing)
+                                        .fixedSize(horizontal: false, vertical: true)
                                     }
                                 }
                             }
@@ -195,6 +198,11 @@ main
         .sheet(isPresented: $showingShareSheet) {
             ShareSheet(items: [shareText])
         }
+        .sheet(item: $selectedDictionaryEntry) { entry in
+            ArabicDictionaryDetailView(entry: entry)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
         .confirmationDialog(LocalizedStringKey("action.edit"), isPresented: $showingActions, presenting: selectedAyahForActions) { ayah in
             Button(LocalizedStringKey("action.copy")) { copyAyah(ayah) }
             Button(LocalizedStringKey("action.share")) { shareAyah(ayah) }
@@ -266,6 +274,21 @@ main
 
     private func formattedText(for ayah: Ayah) -> String {
         "\(viewModel.surahTitle) \(ayah.number): \(ayah.text)"
+    }
+
+    private func handleDictionarySelection(_ word: String) {
+        guard pendingDictionaryWord != word else { return }
+        pendingDictionaryWord = word
+
+        if let entry = ArabicDictionary.shared.lookup(word: word) {
+            selectedDictionaryEntry = entry
+        } else {
+            viewModel.toast = LocalizedStringKey("dictionary.notFound")
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            pendingDictionaryWord = nil
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add an embedded Albanian–Arabic dictionary dataset and loader
- make Arabic verses selectable and surface dictionary definitions from the dataset
- present dictionary details in a dedicated sheet and localize the fallback messaging

## Testing
- not run (iOS app project)

------
https://chatgpt.com/codex/tasks/task_e_68d6810b8aa483319110fd1154d28582