### PR TITLE
Add favorites support with heart actions

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -5,6 +5,7 @@ struct KuraniApp: App {
     @StateObject private var translationStore = TranslationStore()
     @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.shared.client)
     @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.shared.client)
+    @StateObject private var favoritesStore = FavoritesStore()
 
     init() {
         let navigationBarAppearance = UINavigationBar.appearance()
@@ -14,9 +15,10 @@ struct KuraniApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView(translationStore: translationStore, notesStore: notesStore)
+            RootView(translationStore: translationStore, notesStore: notesStore, favoritesStore: favoritesStore)
                 .environmentObject(translationStore)
                 .environmentObject(notesStore)
+                .environmentObject(favoritesStore)
                 .environmentObject(authManager)
                 .preferredColorScheme(.light)
                 .task {

--- a/Models/Ayah.swift
+++ b/Models/Ayah.swift
@@ -7,3 +7,15 @@ struct Ayah: Identifiable, Codable {
 
     var id: Int { number }
 }
+
+struct FavoriteAyah: Identifiable, Codable, Equatable {
+    let surah: Int
+    let ayah: Int
+    let addedAt: Date
+
+    var id: String { Self.id(for: surah, ayah: ayah) }
+
+    static func id(for surah: Int, ayah: Int) -> String {
+        "\(surah)-\(ayah)"
+    }
+}

--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -1,5 +1,6 @@
 "app_name" = "Kurani";
 "tabs.library" = "Suret";
+"tabs.favorites" = "Të preferuarat";
 "tabs.notes" = "Shënimet e mia";
 "tabs.settings" = "Cilësimet";
 
@@ -73,6 +74,12 @@
 "notes.noAccess" = "Hyr për të parë shënimet e tua.";
 "reader.share.subject" = "Ajet nga Kurani";
 "reader.copy.confirmation" = "Teksti u kopjua";
+"reader.favorite.add" = "Shto te të preferuarat";
+"reader.favorite.remove" = "Hiq nga të preferuarat";
 "settings.translation.loaded" = "Përkthimi i ngarkuar";
 "settings.translation.sample" = "Po shfaqet përkthimi i mostrës";
 "reader.jumpLastRead" = "Shko te leximi i fundit";
+"favorites.title" = "Të preferuarat";
+"favorites.empty" = "S’ka ajete të preferuara ende.";
+"favorites.detail" = "Ajeti %d • Sure %@";
+"favorites.remove" = "Hiq nga të preferuarat";

--- a/ViewModels/NotesViewModel.swift
+++ b/ViewModels/NotesViewModel.swift
@@ -25,3 +25,26 @@ final class NotesViewModel: ObservableObject {
         groupedNotes[surah] ?? []
     }
 }
+
+@MainActor
+final class FavoritesViewModel: ObservableObject {
+    @Published private(set) var favorites: [FavoriteAyah] = []
+
+    private let favoritesStore: FavoritesStore
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(favoritesStore: FavoritesStore) {
+        self.favoritesStore = favoritesStore
+        favoritesStore.$favorites
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] favorites in
+                self?.favorites = favorites
+            }
+            .store(in: &cancellables)
+        favorites = favoritesStore.favorites
+    }
+
+    func remove(_ favorite: FavoriteAyah) {
+        favoritesStore.removeFavorite(surah: favorite.surah, ayah: favorite.ayah)
+    }
+}

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -4,11 +4,13 @@ struct ContentView: View {
     @StateObject private var translationStore = TranslationStore()
     @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.shared.client)
     @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.shared.client)
+    @StateObject private var favoritesStore = FavoritesStore()
 
     var body: some View {
-        RootView(translationStore: translationStore, notesStore: notesStore)
+        RootView(translationStore: translationStore, notesStore: notesStore, favoritesStore: favoritesStore)
             .environmentObject(translationStore)
             .environmentObject(notesStore)
+            .environmentObject(favoritesStore)
             .environmentObject(authManager)
             .preferredColorScheme(.light)
             .task {

--- a/Views/LibraryView.swift
+++ b/Views/LibraryView.swift
@@ -11,6 +11,7 @@ struct LibraryView: View {
 
     @EnvironmentObject private var translationStore: TranslationStore
     @EnvironmentObject private var notesStore: NotesStore
+    @EnvironmentObject private var favoritesStore: FavoritesStore
 
     @State private var path: [ReaderRoute] = []
 
@@ -83,7 +84,12 @@ struct LibraryView: View {
             }
             .navigationDestination(for: ReaderRoute.self) { route in
                 ReaderView(
-                    viewModel: ReaderViewModel(surahNumber: route.surah, translationStore: translationStore, notesStore: notesStore),
+                    viewModel: ReaderViewModel(
+                        surahNumber: route.surah,
+                        translationStore: translationStore,
+                        notesStore: notesStore,
+                        favoritesStore: favoritesStore
+                    ),
                     startingAyah: route.ayah,
                     openNotesTab: openNotesTab
                 )

--- a/Views/NotesView.swift
+++ b/Views/NotesView.swift
@@ -10,6 +10,7 @@ struct NotesView: View {
     let translationStore: TranslationStore
 
     @EnvironmentObject private var notesStore: NotesStore
+    @EnvironmentObject private var favoritesStore: FavoritesStore
 
     @State private var path: [ReaderRoute] = []
 
@@ -77,7 +78,12 @@ struct NotesView: View {
             .navigationTitle(LocalizedStringKey("notes.title"))
             .navigationDestination(for: ReaderRoute.self) { route in
                 ReaderView(
-                    viewModel: ReaderViewModel(surahNumber: route.surah, translationStore: translationStore, notesStore: notesStore),
+                    viewModel: ReaderViewModel(
+                        surahNumber: route.surah,
+                        translationStore: translationStore,
+                        notesStore: notesStore,
+                        favoritesStore: favoritesStore
+                    ),
                     startingAyah: route.ayah,
                     openNotesTab: { path = [] }
                 )
@@ -94,5 +100,115 @@ struct NotesView: View {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         return formatter.string(from: date)
+    }
+}
+
+struct FavoritesView: View {
+    struct ReaderRoute: Hashable {
+        let surah: Int
+        let ayah: Int
+    }
+
+    @ObservedObject var viewModel: FavoritesViewModel
+    let openNotesTab: () -> Void
+
+    @EnvironmentObject private var translationStore: TranslationStore
+    @EnvironmentObject private var notesStore: NotesStore
+    @EnvironmentObject private var favoritesStore: FavoritesStore
+
+    @State private var path: [ReaderRoute] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            Group {
+                if viewModel.favorites.isEmpty {
+                    ScrollView {
+                        VStack(spacing: 16) {
+                            Image(systemName: "heart")
+                                .font(.system(size: 48, weight: .thin))
+                                .foregroundStyle(Color.kuraniAccentLight)
+                                .padding(.top, 48)
+
+                            Text(LocalizedStringKey("favorites.empty"))
+                                .font(.system(.body, design: .rounded))
+                                .multilineTextAlignment(.center)
+                                .foregroundColor(.kuraniTextSecondary)
+                                .padding(.horizontal, 32)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 360)
+                    }
+                    .scrollDisabled(true)
+                    .background(KuraniTheme.background.ignoresSafeArea())
+                } else {
+                    List {
+                        ForEach(viewModel.favorites) { favorite in
+                            Button {
+                                path.append(ReaderRoute(surah: favorite.surah, ayah: favorite.ayah))
+                            } label: {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text(ayahText(for: favorite))
+                                        .font(.system(.body, design: .serif))
+                                        .foregroundColor(.kuraniTextPrimary)
+                                        .lineLimit(4)
+
+                                    Text(detailText(for: favorite))
+                                        .font(.system(.caption, design: .rounded))
+                                        .foregroundColor(.kuraniTextSecondary)
+                                }
+                                .appleCard(cornerRadius: 20)
+                                .padding(.horizontal, 20)
+                            }
+                            .buttonStyle(.plain)
+                            .listRowInsets(EdgeInsets())
+                            .listRowBackground(Color.clear)
+                            .padding(.vertical, 6)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    withAnimation {
+                                        viewModel.remove(favorite)
+                                    }
+                                } label: {
+                                    Label(LocalizedStringKey("favorites.remove"), systemImage: "trash")
+                                }
+                            }
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                    .listRowSeparator(.hidden)
+                    .listSectionSpacing(16)
+                    .scrollContentBackground(.hidden)
+                    .background(KuraniTheme.background.ignoresSafeArea())
+                }
+            }
+            .navigationTitle(LocalizedStringKey("favorites.title"))
+            .navigationDestination(for: ReaderRoute.self) { route in
+                ReaderView(
+                    viewModel: ReaderViewModel(
+                        surahNumber: route.surah,
+                        translationStore: translationStore,
+                        notesStore: notesStore,
+                        favoritesStore: favoritesStore
+                    ),
+                    startingAyah: route.ayah,
+                    openNotesTab: {
+                        path = []
+                        openNotesTab()
+                    }
+                )
+            }
+        }
+        .background(KuraniTheme.background.ignoresSafeArea())
+    }
+
+    private func ayahText(for favorite: FavoriteAyah) -> String {
+        translationStore.ayahs(for: favorite.surah).first(where: { $0.number == favorite.ayah })?.text ?? ""
+    }
+
+    private func detailText(for favorite: FavoriteAyah) -> String {
+        String(
+            format: NSLocalizedString("favorites.detail", comment: "favorite metadata"),
+            favorite.ayah,
+            translationStore.title(for: favorite.surah)
+        )
     }
 }

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -71,6 +71,20 @@ main
                                             .lineSpacing(4 * viewModel.lineSpacingScale)
                                     }
                                 }
+
+                                Spacer(minLength: 12)
+
+                                Button {
+                                    viewModel.toggleFavorite(for: ayah)
+                                } label: {
+                                    let isFavorite = viewModel.isFavorite(ayah)
+                                    Image(systemName: isFavorite ? "heart.fill" : "heart")
+                                        .font(.system(size: 18, weight: .semibold))
+                                        .foregroundStyle(isFavorite ? Color.kuraniAccentBrand : Color.kuraniAccentLight.opacity(0.8))
+                                        .accessibilityHidden(true)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(viewModel.isFavorite(ayah) ? LocalizedStringKey("reader.favorite.remove") : LocalizedStringKey("reader.favorite.add"))
                             }
 
                             if let note = viewModel.note(for: ayah) {

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -1,22 +1,26 @@
 import SwiftUI
 
 struct RootView: View {
-    enum Tab { case library, notes, settings }
+    enum Tab { case library, favorites, notes, settings }
 
     @ObservedObject var translationStore: TranslationStore
     @ObservedObject var notesStore: NotesStore
+    @ObservedObject var favoritesStore: FavoritesStore
 
     @StateObject private var libraryViewModel: LibraryViewModel
     @StateObject private var notesViewModel: NotesViewModel
+    @StateObject private var favoritesViewModel: FavoritesViewModel
     @StateObject private var settingsViewModel: SettingsViewModel
 
     @State private var selectedTab: Tab = .library
 
-    init(translationStore: TranslationStore, notesStore: NotesStore) {
+    init(translationStore: TranslationStore, notesStore: NotesStore, favoritesStore: FavoritesStore) {
         self.translationStore = translationStore
         self.notesStore = notesStore
+        self.favoritesStore = favoritesStore
         _libraryViewModel = StateObject(wrappedValue: LibraryViewModel(translationStore: translationStore))
         _notesViewModel = StateObject(wrappedValue: NotesViewModel(notesStore: notesStore))
+        _favoritesViewModel = StateObject(wrappedValue: FavoritesViewModel(favoritesStore: favoritesStore))
         _settingsViewModel = StateObject(wrappedValue: SettingsViewModel(translationStore: translationStore))
     }
 
@@ -31,19 +35,26 @@ struct RootView: View {
             }
             .tag(Tab.library)
 
+            FavoritesView(viewModel: favoritesViewModel, openNotesTab: { selectedTab = .notes })
+                .background(Color.clear)
+                .tabItem {
+                    Label(LocalizedStringKey("tabs.favorites"), systemImage: "heart")
+                }
+                .tag(Tab.favorites)
+
             NotesView(viewModel: notesViewModel, translationStore: translationStore)
-            .background(Color.clear)
-            .tabItem {
-                Label(LocalizedStringKey("tabs.notes"), systemImage: "note.text")
-            }
-            .tag(Tab.notes)
+                .background(Color.clear)
+                .tabItem {
+                    Label(LocalizedStringKey("tabs.notes"), systemImage: "note.text")
+                }
+                .tag(Tab.notes)
 
             SettingsView(viewModel: settingsViewModel)
                 .background(Color.clear)
-            .tabItem {
-                Label(LocalizedStringKey("tabs.settings"), systemImage: "gearshape")
-            }
-            .tag(Tab.settings)
+                .tabItem {
+                    Label(LocalizedStringKey("tabs.settings"), systemImage: "gearshape")
+                }
+                .tag(Tab.settings)
         }
         .tint(Color.kuraniAccentBrand)
         .background(KuraniTheme.background.ignoresSafeArea())


### PR DESCRIPTION
## Summary
- add a FavoritesStore and reader heart button to mark ayahs as favorites
- surface saved favorites in a new heart tab with navigation back to the reader
- localize the new UI strings and wire the store through the app shell

## Testing
- Not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d680c59f488331967b0b7e2923ad7c