### PR TITLE
Apply requested dark theme colors

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -9,8 +9,8 @@ struct KuraniApp: App {
 
     init() {
         let navigationBarAppearance = UINavigationBar.appearance()
-        navigationBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.black]
-        navigationBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.black]
+        navigationBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.kuraniTextPrimary)]
+        navigationBarAppearance.titleTextAttributes = [.foregroundColor: UIColor(Color.kuraniTextPrimary)]
     }
 
     var body: some Scene {

--- a/App/Theme.swift
+++ b/App/Theme.swift
@@ -45,7 +45,7 @@ struct BrandHeader: View {
                 .fill(Color.kuraniAccentLight.opacity(0.22))
                 .overlay(
                     RoundedRectangle(cornerRadius: 30, style: .continuous)
-                        .stroke(Color.black.opacity(0.08), lineWidth: 1.2)
+                        .stroke(Color.kuraniPrimaryBrand.opacity(0.08), lineWidth: 1.2)
                 )
                 .shadow(color: Color.kuraniPrimaryBrand.opacity(0.14), radius: 18, y: 12)
         )
@@ -62,14 +62,14 @@ struct Pill: View {
             .fontWeight(.semibold)
             .padding(.vertical, 6)
             .padding(.horizontal, 12)
-            .foregroundColor(.black)
+            .foregroundColor(.kuraniPrimaryBrand)
             .background(
                 Capsule()
                     .fill(Color.kuraniAccentLight.opacity(0.9))
             )
             .overlay(
                 Capsule()
-                    .stroke(Color.black, lineWidth: 0.8)
+                    .stroke(Color.kuraniPrimaryBrand, lineWidth: 0.8)
             )
             .shadow(color: Color.kuraniAccentBrand.opacity(0.18), radius: 8, y: 4)
     }
@@ -86,7 +86,7 @@ struct GradientButtonStyle: ButtonStyle {
                     .fill(KuraniTheme.accent)
                     .overlay(
                         RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(Color.black.opacity(0.15), lineWidth: 1)
+                            .stroke(Color.kuraniPrimaryBrand.opacity(0.15), lineWidth: 1)
                     )
             )
             .shadow(color: Color.kuraniAccentBrand.opacity(configuration.isPressed ? 0.12 : 0.22), radius: 12, y: 8)
@@ -124,7 +124,7 @@ private struct AppleCardBackground: ViewModifier {
                     .fill(Color.kuraniPrimarySurface)
                     .overlay(
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                            .stroke(Color.kuraniPrimaryBrand.opacity(0.08), lineWidth: 1)
                     )
                     .shadow(color: Color.kuraniPrimaryBrand.opacity(0.08), radius: 10, y: 6)
             )

--- a/Resources/Assets.xcassets/Accent.colorset/Contents.json
+++ b/Resources/Assets.xcassets/Accent.colorset/Contents.json
@@ -5,8 +5,8 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "1.000",
-          "green" : "1.000",
+          "red" : "0.000",
+          "green" : "0.706",
           "blue" : "1.000"
         }
       },

--- a/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
+++ b/Resources/Assets.xcassets/AccentLight.colorset/Contents.json
@@ -4,9 +4,9 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.600",
-          "red" : "1.000",
-          "green" : "1.000",
+          "alpha" : "1.000",
+          "red" : "0.000",
+          "green" : "0.706",
           "blue" : "1.000"
         }
       },

--- a/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
+++ b/Resources/Assets.xcassets/DarkBackground.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.008",
-          "green" : "0.463",
-          "blue" : "0.435"
+          "red" : "0.051",
+          "green" : "0.086",
+          "blue" : "0.161"
         }
       },
       "idiom" : "universal"

--- a/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
+++ b/Resources/Assets.xcassets/PrimarySurface.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "red" : "0.012",
-          "green" : "0.380",
-          "blue" : "0.357"
+          "red" : "0.051",
+          "green" : "0.086",
+          "blue" : "0.161"
         }
       },
       "idiom" : "universal"

--- a/Views/Components/ArabicDictionaryDetailView.swift
+++ b/Views/Components/ArabicDictionaryDetailView.swift
@@ -24,7 +24,7 @@ struct ArabicDictionaryDetailView: View {
                     ForEach(entry.meanings, id: \.self) { meaning in
                         Text("• \(meaning)")
                             .font(.system(size: 16, design: .rounded))
-                            .foregroundColor(.white)
+                            .foregroundColor(.kuraniTextPrimary)
                     }
                 }
 

--- a/Views/Components/ArabicSelectableTextView.swift
+++ b/Views/Components/ArabicSelectableTextView.swift
@@ -49,7 +49,7 @@ struct ArabicSelectableTextView: UIViewRepresentable {
             attributes: [
                 .paragraphStyle: paragraph,
                 .font: UIFont.systemFont(ofSize: fontPointSize, weight: .regular),
-                .foregroundColor: UIColor.white
+                .foregroundColor: UIColor(Color.kuraniTextPrimary)
             ]
         )
         textView.attributedText = attributed

--- a/Views/Components/SignInPromptView.swift
+++ b/Views/Components/SignInPromptView.swift
@@ -25,7 +25,7 @@ struct SignInPromptView: View {
                     .signInWithAppleButtonStyle(.white)
                     .frame(height: 54)
                     .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                    .shadow(color: Color.black.opacity(0.25), radius: 18, y: 12)
+                    .shadow(color: Color.kuraniPrimaryBrand.opacity(0.25), radius: 18, y: 12)
 
                     Divider()
                         .background(Color.kuraniAccentLight.opacity(0.4))

--- a/Views/NoteEditorView.swift
+++ b/Views/NoteEditorView.swift
@@ -26,11 +26,11 @@ struct NoteEditorView: View {
                             .fill(Color.kuraniPrimarySurface.opacity(0.58))
                             .overlay(
                                 RoundedRectangle(cornerRadius: 26, style: .continuous)
-                                    .stroke(Color.black.opacity(0.12), lineWidth: 0.8)
+                                    .stroke(Color.kuraniPrimaryBrand.opacity(0.12), lineWidth: 0.8)
                             )
-                            .shadow(color: Color.black.opacity(0.32), radius: 20, y: 14)
+                            .shadow(color: Color.kuraniPrimaryBrand.opacity(0.32), radius: 20, y: 14)
                     )
-                    .foregroundColor(.black)
+                    .foregroundColor(.kuraniTextPrimary)
                     .font(KuraniFont.forTextStyle(.body))
             }
             .padding(.horizontal, 20)

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -49,7 +49,7 @@ struct ReaderView: View {
 codex/change-font-to-kg-primary-penmanship
                                     Text(ayah.text)
                                         .font(KuraniFont.size(18 * viewModel.fontScale, relativeTo: .body))
-                                        .foregroundColor(.white)
+                                        .foregroundColor(.kuraniTextPrimary)
                                         .lineSpacing(4 * viewModel.lineSpacingScale)
                                         .contextMenu {
                                             Button(LocalizedStringKey("action.edit")) {
@@ -61,7 +61,7 @@ codex/change-font-to-kg-primary-penmanship
                                     if showAlbanianText {
                                         Text(ayah.text)
                                             .font(.system(size: 18 * viewModel.fontScale, weight: .regular, design: .serif))
-                                            .foregroundColor(.white)
+                                            .foregroundColor(.kuraniTextPrimary)
                                             .lineSpacing(4 * viewModel.lineSpacingScale)
                                             .contextMenu {
                                                 Button(LocalizedStringKey("action.edit")) {
@@ -137,7 +137,7 @@ codex/add-button-to-redirect-with-ayah-details
                                         .fill(Color.kuraniPrimarySurface.opacity(0.68))
                                         .overlay(
                                             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                                                .stroke(Color.black.opacity(0.12), lineWidth: 0.6)
+                                                .stroke(Color.kuraniPrimaryBrand.opacity(0.12), lineWidth: 0.6)
                                         )
                                 )
                             }


### PR DESCRIPTION
## Summary
- update the shared color assets to use the requested dark background, white text, and bright blue accent shades
- apply the refreshed palette across reader, dictionary, and note editor views so ayahs, icons, and controls match the theme
- align navigation styling and reusable components (cards, buttons, pills) with the new icon/line color

## Testing
- not run (iOS project without automated tests in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d687b6fde48331b660af30333ff634