### PR TITLE
Fix corrupted Xcode project file

### DIFF
--- a/Kurani.xcodeproj/project.pbxproj
+++ b/Kurani.xcodeproj/project.pbxproj
@@ -136,17 +136,17 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
 			path = App;
 			sourceTree = "<group>";
 		};
-                D47AD4DA2A6B02A30000000E /* Models */ = {
-                        isa = PBXGroup;
-                        children = (
-                                D47AD4DA2A6B02A300000022 /* Ayah.swift */,
-                                D47AD4DA2A6B02A300000023 /* Surah.swift */,
-                                D47AD4DA2A6B02A300000024 /* Note.swift */,
-                                D4F6B6D12C9F000100000091 /* ArabicDictionaryEntry.swift */,
-                        );
-                        path = Models;
-                        sourceTree = "<group>";
-                };
+		D47AD4DA2A6B02A30000000E /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				D47AD4DA2A6B02A300000022 /* Ayah.swift */,
+				D47AD4DA2A6B02A300000023 /* Surah.swift */,
+				D47AD4DA2A6B02A300000024 /* Note.swift */,
+				D4F6B6D12C9F000100000091 /* ArabicDictionaryEntry.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		D47AD4DA2A6B02A30000000F /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -163,17 +163,17 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
 			path = Views;
 			sourceTree = "<group>";
 		};
-                D47AD4DA2A6B02A300000010 /* Components */ = {
-                        isa = PBXGroup;
-                        children = (
-                                333054A5288A4EB490D5C514 /* ProgressBadge.swift */,
-                                D4F6B6D52C9F000100000095 /* ArabicSelectableTextView.swift */,
-                                D4F6B6D72C9F000100000097 /* ArabicDictionaryDetailView.swift */,
-                                D47AD4DA2A6B02A300000038 /* SignInPromptView.swift */,
-                        );
-                        path = Components;
-                        sourceTree = "<group>";
-                };
+		D47AD4DA2A6B02A300000010 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				333054A5288A4EB490D5C514 /* ProgressBadge.swift */,
+				D4F6B6D52C9F000100000095 /* ArabicSelectableTextView.swift */,
+				D4F6B6D72C9F000100000097 /* ArabicDictionaryDetailView.swift */,
+				D47AD4DA2A6B02A300000038 /* SignInPromptView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		D47AD4DA2A6B02A300000011 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -185,22 +185,19 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
-                D47AD4DA2A6B02A300000012 /* Utils */ = {
-                        isa = PBXGroup;
-                        children = (
-                                D47AD4DA2A6B02A300000028 /* ShareSheet.swift */,
-                                D47AD4DA2A6B02A300000029 /* FileIO.swift */,
-                                D47AD4DA2A6B02A30000002A /* Haptics.swift */,
-                                D47AD4DA2A6B02A30000002B /* AppStorageKeys.swift */,
- codex/change-font-to-kg-primary-penmanship
-                                D4FF6AAA2D00000100000092 /* KuraniFont.swift */,
-
-                                D4F6B6D32C9F000100000093 /* ArabicDictionary.swift */,
- main
-                        );
-                        path = Utils;
-                        sourceTree = "<group>";
-                };
+		D47AD4DA2A6B02A300000012 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				D47AD4DA2A6B02A300000028 /* ShareSheet.swift */,
+				D47AD4DA2A6B02A300000029 /* FileIO.swift */,
+				D47AD4DA2A6B02A30000002A /* Haptics.swift */,
+				D47AD4DA2A6B02A30000002B /* AppStorageKeys.swift */,
+				D4FF6AAA2D00000100000092 /* KuraniFont.swift */,
+				D4F6B6D32C9F000100000093 /* ArabicDictionary.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		D47AD4DA2A6B02A300000013 /* Supabase */ = {
 			isa = PBXGroup;
 			children = (
@@ -211,46 +208,26 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
 			path = Supabase;
 			sourceTree = "<group>";
 		};
-codex/change-font-to-kg-primary-penmanship
-D47AD4DA2A6B02A300000014 /* Data */ = {
-isa = PBXGroup;
-children = (
-D47AD4DA2A6B02A30000001F /* TranslationStore.swift */,
-D47AD4DA2A6B02A300000020 /* QuranMeta.json */,
-D47AD4DA2A6B02A300000021 /* sample_translation.json */,
-D4F6B6C12C9F000100000080 /* ArabicText.json */,
-);
-path = Data;
-sourceTree = "<group>";
-};
-                D47AD4DA2A6B02A300000015 /* Resources */ = {
-                        isa = PBXGroup;
-                        children = (
-                                D4FF6AAA2D00000100000090 /* Fonts */,
-                                D4FA5A8D2B12345600000060 /* LaunchScreen.storyboard */,
-                                D47AD4DA2A6B02A300000019 /* Assets.xcassets */,
-                                D47AD4DA2A6B02A300000039 /* Localizable.strings */,
-
-                D47AD4DA2A6B02A300000014 /* Data */ = {
-                        isa = PBXGroup;
-                        children = (
-                                A788809F18B943D3B6063A5A /* ReadingProgressStore.swift */,
-                                D47AD4DA2A6B02A30000001F /* TranslationStore.swift */,
-                                D47AD4DA2A6B02A300000020 /* QuranMeta.json */,
-                                D47AD4DA2A6B02A300000021 /* sample_translation.json */,
-                                D4F6B6C12C9F000100000080 /* ArabicText.json */,
-                                D4F6B6D92C9F000100000099 /* ArabicDictionary.json */,
-                        );
-                        path = Data;
-                        sourceTree = "<group>";
-                };
+		D47AD4DA2A6B02A300000014 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				A788809F18B943D3B6063A5A /* ReadingProgressStore.swift */,
+				D47AD4DA2A6B02A30000001F /* TranslationStore.swift */,
+				D47AD4DA2A6B02A300000020 /* QuranMeta.json */,
+				D47AD4DA2A6B02A300000021 /* sample_translation.json */,
+				D4F6B6C12C9F000100000080 /* ArabicText.json */,
+				D4F6B6D92C9F000100000099 /* ArabicDictionary.json */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
 		D47AD4DA2A6B02A300000015 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				D4FF6AAA2D00000100000090 /* Fonts */,
 				D4FA5A8D2B12345600000060 /* LaunchScreen.storyboard */,
 				D47AD4DA2A6B02A300000019 /* Assets.xcassets */,
 				D47AD4DA2A6B02A300000039 /* Localizable.strings */,
-main
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -319,33 +296,19 @@ main
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-codex/change-font-to-kg-primary-penmanship
-                D47AD4DA2A6B02A30000000B /* Resources */ = {
-                        isa = PBXResourcesBuildPhase;
-                        buildActionMask = 2147483647;
-                        files = (
-                                D4FF6AAA2D00000100000091 /* Fonts in Resources */,
-                                D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */,
-                                D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */,
-                                D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */,
-D4F6B6C22C9F000100000081 /* ArabicText.json in Resources */,
-D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */,
-D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
-);
-
 		D47AD4DA2A6B02A30000000B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
-                        files = (
-                                D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */,
-                                D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */,
-                                D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */,
-                                D4F6B6D82C9F000100000098 /* ArabicDictionary.json in Resources */,
-                                D4F6B6C22C9F000100000081 /* ArabicText.json in Resources */,
-                                D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */,
-                                D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
-                        );
-main
+			files = (
+				D4FF6AAA2D00000100000091 /* Fonts in Resources */,
+				D4FA5A8D2B12345600000061 /* LaunchScreen.storyboard in Resources */,
+				D47AD4DA2A6B02A300000058 /* Localizable.strings in Resources */,
+				D47AD4DA2A6B02A300000057 /* sample_translation.json in Resources */,
+				D4F6B6D82C9F000100000098 /* ArabicDictionary.json in Resources */,
+				D4F6B6C22C9F000100000081 /* ArabicText.json in Resources */,
+				D47AD4DA2A6B02A300000056 /* QuranMeta.json in Resources */,
+				D47AD4DA2A6B02A300000055 /* Assets.xcassets in Resources */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
@@ -361,38 +324,32 @@ main
 				D47AD4DA2A6B02A300000051 /* RootView.swift in Sources */,
 				D47AD4DA2A6B02A300000050 /* NotesView.swift in Sources */,
 				D47AD4DA2A6B02A30000004F /* NoteEditorView.swift in Sources */,
-                                D47AD4DA2A6B02A30000004E /* SettingsView.swift in Sources */,
-                                D47AD4DA2A6B02A30000004D /* LibraryView.swift in Sources */,
-                                E4474F56488F4C62929FB0C8 /* ProgressBadge.swift in Sources */,
-                                D47AD4DA2A6B02A30000004C /* ReaderView.swift in Sources */,
-                                D4F6B6D62C9F000100000096 /* ArabicDictionaryDetailView.swift in Sources */,
-                                D4F6B6D42C9F000100000094 /* ArabicSelectableTextView.swift in Sources */,
-                                D47AD4DA2A6B02A30000004B /* SettingsViewModel.swift in Sources */,
+				D47AD4DA2A6B02A30000004E /* SettingsView.swift in Sources */,
+				D47AD4DA2A6B02A30000004D /* LibraryView.swift in Sources */,
+				E4474F56488F4C62929FB0C8 /* ProgressBadge.swift in Sources */,
+				D47AD4DA2A6B02A30000004C /* ReaderView.swift in Sources */,
+				D4F6B6D62C9F000100000096 /* ArabicDictionaryDetailView.swift in Sources */,
+				D4F6B6D42C9F000100000094 /* ArabicSelectableTextView.swift in Sources */,
+				D47AD4DA2A6B02A30000004B /* SettingsViewModel.swift in Sources */,
 				D47AD4DA2A6B02A30000004A /* ReaderViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000049 /* NotesViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000048 /* LibraryViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000047 /* AppStorageKeys.swift in Sources */,
-codex/change-font-to-kg-primary-penmanship
-                                D47AD4DA2A6B02A300000046 /* Haptics.swift in Sources */,
-                                D4FF6AAA2D00000100000093 /* KuraniFont.swift in Sources */,
-                                D47AD4DA2A6B02A300000045 /* FileIO.swift in Sources */,
-				D47AD4DA2A6B02A300000044 /* ShareSheet.swift in Sources */,
-
 				D47AD4DA2A6B02A300000046 /* Haptics.swift in Sources */,
-                                D47AD4DA2A6B02A300000045 /* FileIO.swift in Sources */,
-                                D4F6B6D22C9F000100000092 /* ArabicDictionary.swift in Sources */,
-                                D47AD4DA2A6B02A300000044 /* ShareSheet.swift in Sources */,
- main
+				D4FF6AAA2D00000100000093 /* KuraniFont.swift in Sources */,
+				D47AD4DA2A6B02A300000045 /* FileIO.swift in Sources */,
+				D47AD4DA2A6B02A300000044 /* ShareSheet.swift in Sources */,
+				D4F6B6D22C9F000100000092 /* ArabicDictionary.swift in Sources */,
 				D47AD4DA2A6B02A300000043 /* SupabaseClientProvider.swift in Sources */,
 				D47AD4DA2A6B02A300000042 /* AuthManager.swift in Sources */,
-                                D47AD4DA2A6B02A300000041 /* NotesStore.swift in Sources */,
-                                D47AD4DA2A6B02A300000040 /* Note.swift in Sources */,
-                                D4F6B6D02C9F000100000090 /* ArabicDictionaryEntry.swift in Sources */,
-                                D47AD4DA2A6B02A30000003F /* Surah.swift in Sources */,
-                                D47AD4DA2A6B02A30000003E /* Ayah.swift in Sources */,
-                                D47AD4DA2A6B02A30000003D /* TranslationStore.swift in Sources */,
-                                F8643BD45C394BFFA5D99674 /* ReadingProgressStore.swift in Sources */,
-                                D47AD4DA2A6B02A30000003C /* Theme.swift in Sources */,
+				D47AD4DA2A6B02A300000041 /* NotesStore.swift in Sources */,
+				D47AD4DA2A6B02A300000040 /* Note.swift in Sources */,
+				D4F6B6D02C9F000100000090 /* ArabicDictionaryEntry.swift in Sources */,
+				D47AD4DA2A6B02A30000003F /* Surah.swift in Sources */,
+				D47AD4DA2A6B02A30000003E /* Ayah.swift in Sources */,
+				D47AD4DA2A6B02A30000003D /* TranslationStore.swift in Sources */,
+				F8643BD45C394BFFA5D99674 /* ReadingProgressStore.swift in Sources */,
+				D47AD4DA2A6B02A30000003C /* Theme.swift in Sources */,
 				D47AD4DA2A6B02A30000003B /* QuranApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Summary
- clean PBXGroup definitions to remove stray merge text and restore the expected project hierarchy
- rebuild the Resources and Sources build phases with the correct file lists so Xcode can parse the project

## Testing
- not run (Xcode project file cleanup)


------
https://chatgpt.com/codex/tasks/task_e_68d68affe6b083318990d262e64d642f