### PR TITLE
Fix build issues in RootView initialization and font utility

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -19,8 +19,8 @@ struct KuraniApp: App {
             RootView(
                 translationStore: translationStore,
                 notesStore: notesStore,
-                favoritesStore: favoritesStore,
-                progressStore: progressStore
+                progressStore: progressStore,
+                favoritesStore: favoritesStore
             )
                 .environmentObject(translationStore)
                 .environmentObject(notesStore)

--- a/Utils/KuraniFont.swift
+++ b/Utils/KuraniFont.swift
@@ -5,7 +5,8 @@ enum KuraniFont {
     static let name = "KG Primary Penmanship"
 
     static func forTextStyle(_ style: Font.TextStyle) -> Font {
-        let baseSize = UIFont.preferredFont(forTextStyle: style).pointSize
+        let uiTextStyle = UIFont.TextStyle(style)
+        let baseSize = UIFont.preferredFont(forTextStyle: uiTextStyle).pointSize
         return Font.custom(name, size: baseSize, relativeTo: style)
     }
 
@@ -15,5 +16,24 @@ enum KuraniFont {
 
     static func size(_ size: CGFloat, relativeTo style: Font.TextStyle) -> Font {
         Font.custom(name, size: size, relativeTo: style)
+    }
+}
+
+private extension UIFont.TextStyle {
+    init(_ style: Font.TextStyle) {
+        switch style {
+        case .largeTitle: self = .largeTitle
+        case .title: self = .title1
+        case .title2: self = .title2
+        case .title3: self = .title3
+        case .headline: self = .headline
+        case .subheadline: self = .subheadline
+        case .body: self = .body
+        case .callout: self = .callout
+        case .footnote: self = .footnote
+        case .caption: self = .caption1
+        case .caption2: self = .caption2
+        @unknown default: self = .body
+        }
     }
 }

--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -21,7 +21,7 @@ final class ReaderViewModel: ObservableObject {
     private let translationStore: TranslationStore
     private let notesStore: NotesStore
     private let favoritesStore: FavoritesStore
-    private let progressStore: ReadingProgressStore
+    private let readingProgressStore: ReadingProgressStore
     private var cancellables: Set<AnyCancellable> = []
 
     init(
@@ -35,7 +35,7 @@ final class ReaderViewModel: ObservableObject {
         self.translationStore = translationStore
         self.notesStore = notesStore
         self.favoritesStore = favoritesStore
-        self.progressStore = progressStore
+        self.readingProgressStore = progressStore
 
         let storedFont = UserDefaults.standard.double(forKey: AppStorageKeys.fontScale)
         fontScale = storedFont == 0 ? 1.0 : storedFont
@@ -101,7 +101,7 @@ final class ReaderViewModel: ObservableObject {
     func updateLastRead(ayah: Int) {
         UserDefaults.standard.set(surahNumber, forKey: AppStorageKeys.lastReadSurah)
         UserDefaults.standard.set(ayah, forKey: AppStorageKeys.lastReadAyah)
-        progressStore.updateHighestAyah(ayah, for: surahNumber, totalAyahs: totalAyahs)
+        readingProgressStore.updateHighestAyah(ayah, for: surahNumber, totalAyahs: totalAyahs)
         refreshProgress()
     }
 
@@ -134,7 +134,7 @@ final class ReaderViewModel: ObservableObject {
     }
 
     private func observeProgressChanges() {
-        progressStore.$highestReadAyahBySurah
+        readingProgressStore.$highestReadAyahBySurah
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshProgress()
@@ -143,10 +143,10 @@ final class ReaderViewModel: ObservableObject {
     }
 
     private func refreshProgress() {
-        highestAyahRead = progressStore.highestAyahRead(for: surahNumber)
+        highestAyahRead = readingProgressStore.highestAyahRead(for: surahNumber)
         if totalAyahs == 0 {
             totalAyahs = translationStore.ayahCount(for: surahNumber)
         }
-        readingProgress = progressStore.progress(for: surahNumber, totalAyahs: totalAyahs)
+        readingProgress = readingProgressStore.progress(for: surahNumber, totalAyahs: totalAyahs)
     }
 }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -11,8 +11,8 @@ struct ContentView: View {
         RootView(
             translationStore: translationStore,
             notesStore: notesStore,
-            favoritesStore: favoritesStore,
-            progressStore: progressStore
+            progressStore: progressStore,
+            favoritesStore: favoritesStore
         )
             .environmentObject(translationStore)
             .environmentObject(notesStore)

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -5,8 +5,8 @@ struct RootView: View {
 
     @ObservedObject var translationStore: TranslationStore
     @ObservedObject var notesStore: NotesStore
-    @ObservedObject var favoritesStore: FavoritesStore
     @ObservedObject var progressStore: ReadingProgressStore
+    @ObservedObject var favoritesStore: FavoritesStore
 
     @StateObject private var libraryViewModel: LibraryViewModel
     @StateObject private var notesViewModel: NotesViewModel
@@ -18,13 +18,13 @@ struct RootView: View {
     init(
         translationStore: TranslationStore,
         notesStore: NotesStore,
-        favoritesStore: FavoritesStore,
-        progressStore: ReadingProgressStore
+        progressStore: ReadingProgressStore,
+        favoritesStore: FavoritesStore
     ) {
         self.translationStore = translationStore
         self.notesStore = notesStore
-        self.favoritesStore = favoritesStore
         self.progressStore = progressStore
+        self.favoritesStore = favoritesStore
         _libraryViewModel = StateObject(wrappedValue: LibraryViewModel(translationStore: translationStore))
         _notesViewModel = StateObject(wrappedValue: NotesViewModel(notesStore: notesStore))
         _favoritesViewModel = StateObject(wrappedValue: FavoritesViewModel(favoritesStore: favoritesStore))


### PR DESCRIPTION
## Summary
- reorder `RootView` initializers and call sites so `ReadingProgressStore` and `FavoritesStore` arguments match the expected order
- rename the stored progress dependency in `ReaderViewModel` to avoid redeclaration conflicts with generated symbols
- map SwiftUI text styles to their UIKit equivalents before asking `UIFont` for preferred sizes in `KuraniFont`

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6930aa81083318680df29c472ea58