### PR TITLE
Fix property redeclaration errors in RootView

### DIFF
--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 struct RootView: View {
     enum Tab { case library, favorites, notes, settings }
 
-    @ObservedObject var translationStore: TranslationStore
-    @ObservedObject var notesStore: NotesStore
-    @ObservedObject var progressStore: ReadingProgressStore
-    @ObservedObject var favoritesStore: FavoritesStore
+    let translationStore: TranslationStore
+    let notesStore: NotesStore
+    let progressStore: ReadingProgressStore
+    let favoritesStore: FavoritesStore
 
     @StateObject private var libraryViewModel: LibraryViewModel
     @StateObject private var notesViewModel: NotesViewModel


### PR DESCRIPTION
## Summary
- replace `@ObservedObject` wrappers for the injected stores in `RootView` with plain stored references to avoid duplicate property wrapper synthesis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b12f2ea08331ae24d56cd7fca5ce