### PR TITLE
Update edit button label to Sheno

### DIFF
--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -13,7 +13,7 @@
 "action.search" = "Kërko";
 "action.copy" = "Kopjo";
 "action.share" = "Ndaj";
-"action.edit" = "Ndrysho";
+"action.edit" = "Sheno";
 "action.add" = "Shto";
 "action.signin" = "Hyr";
 "action.signout" = "Dil";


### PR DESCRIPTION
## Summary
- rename the localized edit button label from "Ndrysho" to "Sheno"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6baf1fb0883318234ca94389f4aa2