### PR TITLE
Fix TextKit compatibility warning and simulator haptic error

### DIFF
--- a/Utils/Haptics.swift
+++ b/Utils/Haptics.swift
@@ -6,7 +6,7 @@ import CoreHaptics
 
 enum Haptics {
     private static let supportsHaptics: Bool = {
-#if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst) || targetEnvironment(simulator)
         return false
 #else
 #if canImport(CoreHaptics)

--- a/Views/Components/ArabicSelectableTextView.swift
+++ b/Views/Components/ArabicSelectableTextView.swift
@@ -18,7 +18,6 @@ struct ArabicSelectableTextView: UIViewRepresentable {
         textView.dataDetectorTypes = []
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
-        textView.layoutManager.allowsNonContiguousLayout = false
         textView.delegate = context.coordinator
         textView.tintColor = UIColor(Color.kuraniAccentLight)
         textView.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
## Summary
- stop forcing UITextView to fall back to TextKit 1 compatibility mode
- avoid querying CoreHaptics capabilities when running in the iOS simulator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bac98b0c8331892e01418474bd35