### PR TITLE
Ensure Arabic text view expands in portrait

### DIFF
--- a/Views/Components/ArabicSelectableTextView.swift
+++ b/Views/Components/ArabicSelectableTextView.swift
@@ -8,7 +8,7 @@ struct ArabicSelectableTextView: UIViewRepresentable {
     let onSelection: (String) -> Void
 
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+        let textView = IntrinsicTextView()
         textView.backgroundColor = .clear
         textView.textAlignment = .right
         textView.semanticContentAttribute = .forceRightToLeft
@@ -53,8 +53,6 @@ struct ArabicSelectableTextView: UIViewRepresentable {
             ]
         )
         textView.attributedText = attributed
-        textView.setNeedsLayout()
-        textView.layoutIfNeeded()
         textView.invalidateIntrinsicContentSize()
     }
 
@@ -83,6 +81,31 @@ struct ArabicSelectableTextView: UIViewRepresentable {
                 textView.selectedTextRange = nil
                 self.lastSelection = nil
             }
+        }
+    }
+}
+
+private final class IntrinsicTextView: UITextView {
+    private var previousBounds: CGSize = .zero
+
+    override var intrinsicContentSize: CGSize {
+        let targetWidth: CGFloat
+        if bounds.width > 0 {
+            targetWidth = bounds.width
+        } else {
+            targetWidth = UIScreen.main.bounds.width - layoutMargins.left - layoutMargins.right
+        }
+
+        let size = CGSize(width: targetWidth, height: CGFloat.greatestFiniteMagnitude)
+        let fitting = sizeThatFits(size)
+        return CGSize(width: UIView.noIntrinsicMetric, height: fitting.height)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if bounds.size != previousBounds {
+            previousBounds = bounds.size
+            invalidateIntrinsicContentSize()
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the Arabic reader UITextView with a subclass that recalculates its intrinsic height when the bounds change
- invalidate the intrinsic size during updates so the Arabic text stretches correctly in portrait orientation

## Testing
- Not run (not easily runnable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6bcb811688331917ffff8978ee615