### PR TITLE
Align favorite folder picker with app theme

### DIFF
--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 "settings.account.offline" = "Hyrja është çaktivizuar përkohësisht. Shënimet do të ruhen vetëm në këtë pajisje.";
 "settings.progress.title" = "Hatmja ime";
 "settings.progress.description" = "Rivendos leximet dhe përqindjen e çdo sureje.";
-"settings.progress.reset" = "Rivendos hatmen";
+"settings.progress.reset" = "Rifillo hatmen";
 "settings.progress.resetConfirm" = "Jeni i sigurt që doni t’i ktheni në zero të gjitha përqindjet e leximit?";
 "settings.progress.resetConfirmButton" = "Po, rivendos";
 "settings.progress.resetSuccess" = "Leximet u rivendosën";

--- a/Views/Components/FavoriteFolderPickerView.swift
+++ b/Views/Components/FavoriteFolderPickerView.swift
@@ -55,12 +55,14 @@ struct FavoriteFolderPickerView: View {
                             .padding(.top, 6)
                     }
                 }
+                .listRowBackground(Color.kuraniPrimarySurface.opacity(0.65))
 
                 Section(header: Text(LocalizedStringKey("favorites.folderPicker.existing"))) {
                     if favoritesStore.folders.isEmpty {
                         Text(LocalizedStringKey("favorites.folderPicker.noFolders"))
                             .font(.system(.footnote, design: .rounded))
                             .foregroundColor(.kuraniTextSecondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     } else {
                         ForEach(favoritesStore.folders) { folder in
                             Button {
@@ -82,10 +84,13 @@ struct FavoriteFolderPickerView: View {
                                             .foregroundColor(.kuraniAccentLight)
                                     }
                                 }
+                                .padding(.vertical, 4)
                             }
+                            .listRowBackground(Color.kuraniPrimarySurface.opacity(0.45))
                         }
                     }
                 }
+                .listRowBackground(Color.kuraniPrimarySurface.opacity(0.45))
 
                 Section(header: Text(LocalizedStringKey("favorites.folderPicker.new"))) {
                     TextField(LocalizedStringKey("favorites.folderPicker.placeholder"), text: $newFolderName)
@@ -98,7 +103,11 @@ struct FavoriteFolderPickerView: View {
                     }
                     .disabled(newFolderName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
+                .listRowBackground(Color.kuraniPrimarySurface.opacity(0.65))
             }
+            .scrollContentBackground(.hidden)
+            .listRowSeparator(.hidden)
+            .background(KuraniTheme.background.ignoresSafeArea())
             .navigationTitle(LocalizedStringKey("favorites.folderPicker.title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -110,8 +119,9 @@ struct FavoriteFolderPickerView: View {
                 }
             }
         }
+        .tint(.kuraniAccentLight)
+        .background(KuraniTheme.background.ignoresSafeArea())
     }
-
     private func folderDetail(for folder: FavoriteFolder) -> String {
         let count = folder.entries.count
         if count == 1 {


### PR DESCRIPTION
## Summary
- restyle the favorite folder picker form to hide the white background, tint controls, and apply surface colors so folders remain visible
- rename the reading progress reset action in settings to “Rifillo hatmen”

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d6c2fa3a08833191ec8647992f6874