### PR TITLE
Add configurable reading reminders and verse notifications

### DIFF
--- a/Data/TranslationStore.swift
+++ b/Data/TranslationStore.swift
@@ -99,6 +99,20 @@ final class TranslationStore: ObservableObject {
         surahs.first(where: { $0.number == surah })?.name ?? ""
     }
 
+    func randomAyahs(count: Int) -> [(surah: Int, ayah: Ayah)] {
+        guard count > 0 else { return [] }
+        let allAyahs: [(Int, Ayah)] = ayahsBySurah
+            .sorted { $0.key < $1.key }
+            .flatMap { (surah, ayahs) in ayahs.map { (surah, $0) } }
+        guard !allAyahs.isEmpty else { return [] }
+
+        let limit = min(count, allAyahs.count)
+        var indices = Array(allAyahs.indices)
+        indices.shuffle()
+
+        return indices.prefix(limit).map { allAyahs[$0] }
+    }
+
     private func applyArabicTextIfAvailable(to ayahs: [Ayah], surahNumber: Int) -> [Ayah] {
         guard let arabicMap = arabicAyahsBySurah[surahNumber] else { return ayahs }
         return ayahs.map { ayah in

--- a/Kurani.xcodeproj/project.pbxproj
+++ b/Kurani.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@ D4F6B6D42C9F000100000094 /* ArabicSelectableTextView.swift in Sources */ = {isa 
                 F8643BD45C394BFFA5D99674 /* ReadingProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A788809F18B943D3B6063A5A /* ReadingProgressStore.swift */; };
                 E4474F56488F4C62929FB0C8 /* ProgressBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333054A5288A4EB490D5C514 /* ProgressBadge.swift */; };
                 D4F6B6E42C9F0001000000AA /* FavoriteFolderPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6E32C9F0001000000AA /* FavoriteFolderPickerView.swift */; };
+                D4F6B6F82C9F0001000000B3 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6F72C9F0001000000B2 /* NotificationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -74,6 +75,7 @@ D4F6B6D52C9F000100000095 /* ArabicSelectableTextView.swift */ = {isa = PBXFileRe
                 A788809F18B943D3B6063A5A /* ReadingProgressStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingProgressStore.swift; sourceTree = "<group>"; };
                 333054A5288A4EB490D5C514 /* ProgressBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBadge.swift; sourceTree = "<group>"; };
                 D4F6B6E32C9F0001000000AA /* FavoriteFolderPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteFolderPickerView.swift; sourceTree = "<group>"; };
+                D4F6B6F72C9F0001000000B2 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
                 D47AD4DA2A6B02A300000025 /* NotesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesStore.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A300000026 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A300000027 /* SupabaseClientProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClientProvider.swift; sourceTree = "<group>"; };
@@ -192,11 +194,12 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
 			isa = PBXGroup;
 			children = (
 				D47AD4DA2A6B02A300000028 /* ShareSheet.swift */,
-				D47AD4DA2A6B02A300000029 /* FileIO.swift */,
-				D47AD4DA2A6B02A30000002A /* Haptics.swift */,
-				D47AD4DA2A6B02A30000002B /* AppStorageKeys.swift */,
-				D4FF6AAA2D00000100000092 /* KuraniFont.swift */,
-				D4F6B6D32C9F000100000093 /* ArabicDictionary.swift */,
+                                D47AD4DA2A6B02A300000029 /* FileIO.swift */,
+                                D47AD4DA2A6B02A30000002A /* Haptics.swift */,
+                                D47AD4DA2A6B02A30000002B /* AppStorageKeys.swift */,
+                                D4F6B6F72C9F0001000000B2 /* NotificationManager.swift */,
+                                D4FF6AAA2D00000100000092 /* KuraniFont.swift */,
+                                D4F6B6D32C9F000100000093 /* ArabicDictionary.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -338,8 +341,9 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
 				D47AD4DA2A6B02A30000004A /* ReaderViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000049 /* NotesViewModel.swift in Sources */,
 				D47AD4DA2A6B02A300000048 /* LibraryViewModel.swift in Sources */,
-				D47AD4DA2A6B02A300000047 /* AppStorageKeys.swift in Sources */,
-				D47AD4DA2A6B02A300000046 /* Haptics.swift in Sources */,
+                                D47AD4DA2A6B02A300000047 /* AppStorageKeys.swift in Sources */,
+                                D4F6B6F82C9F0001000000B3 /* NotificationManager.swift in Sources */,
+                                D47AD4DA2A6B02A300000046 /* Haptics.swift in Sources */,
 				D4FF6AAA2D00000100000093 /* KuraniFont.swift in Sources */,
 				D47AD4DA2A6B02A300000045 /* FileIO.swift in Sources */,
 				D47AD4DA2A6B02A300000044 /* ShareSheet.swift in Sources */,

--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -52,6 +52,26 @@
 "settings.progress.resetSuccess" = "Leximet u rivendosën";
 "settings.about" = "Rreth aplikacionit";
 
+"settings.notifications.title" = "Njoftimet";
+"settings.notifications.readingReminder" = "Kujtues leximi";
+"settings.notifications.readingReminderDescription" = "Zgjidh kohën kur dëshiron të të kujtohet të lexosh.";
+"settings.notifications.timeLabel" = "Koha e kujtuesit";
+"settings.notifications.reminderEnabled" = "Kujtuesi i leximit u aktivizua.";
+"settings.notifications.reminderDisabled" = "Kujtuesi i leximit u çaktivizua.";
+"settings.notifications.reminderTimeUpdated" = "Koha e kujtuesit u përditësua.";
+"settings.notifications.permissionDenied" = "Lejet për njoftime janë të çaktivizuara.";
+"settings.notifications.error" = "S’u planifikuan dot njoftimet.";
+"settings.notifications.verseOfDay" = "Ajeti i ditës";
+"settings.notifications.verseOfDayDescription" = "Çdo ditë në orën 07:00 do të marrësh një ajet të rastësishëm.";
+"settings.notifications.verseEnabled" = "Ajeti i ditës u aktivizua.";
+"settings.notifications.verseDisabled" = "Ajeti i ditës u çaktivizua.";
+"settings.notifications.verseUnavailable" = "Teksti i ajeteve s’është i disponueshëm ende.";
+
+"notification.readingReminder.title" = "Koha për të lexuar";
+"notification.readingReminder.body" = "Hap Kurani për të vazhduar leximin tënd.";
+"notification.verseOfDay.title" = "Ajeti i ditës";
+"notification.verseOfDay.body" = "%@\nSure %@ • Ajeti %d";
+
 "notes.lastUpdated" = "Përditësuar: %@";
 "notes.section" = "Sure %@";
 "notes.openReader" = "Hap leximin";

--- a/Utils/NotificationManager.swift
+++ b/Utils/NotificationManager.swift
@@ -1,0 +1,108 @@
+import Foundation
+import UserNotifications
+
+final class NotificationManager {
+    static let shared = NotificationManager()
+
+    private let center = UNUserNotificationCenter.current()
+
+    private init() {}
+
+    func authorizationStatus() async -> UNAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            center.getNotificationSettings { settings in
+                continuation.resume(returning: settings.authorizationStatus)
+            }
+        }
+    }
+
+    func requestAuthorization() async -> Bool {
+        do {
+            return try await center.requestAuthorization(options: [.alert, .sound, .badge])
+        } catch {
+            print("Failed to request notification authorization", error)
+            return false
+        }
+    }
+
+    func scheduleReadingReminder(at components: DateComponents) async throws {
+        var dateComponents = components
+        dateComponents.second = 0
+        cancelReadingReminder()
+
+        let content = UNMutableNotificationContent()
+        content.title = NSLocalizedString("notification.readingReminder.title", comment: "Reading reminder title")
+        content.body = NSLocalizedString("notification.readingReminder.body", comment: "Reading reminder body")
+        content.sound = .default
+
+        let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+        let request = UNNotificationRequest(
+            identifier: Self.readingReminderIdentifier,
+            content: content,
+            trigger: trigger
+        )
+
+        try await add(request)
+    }
+
+    func cancelReadingReminder() {
+        center.removePendingNotificationRequests(withIdentifiers: [Self.readingReminderIdentifier])
+    }
+
+    func scheduleVerseOfDayNotifications(_ notifications: [(DateComponents, String)]) async throws {
+        await cancelVerseOfDay()
+
+        for (index, entry) in notifications.enumerated() {
+            var components = entry.0
+            components.second = 0
+
+            let content = UNMutableNotificationContent()
+            content.title = NSLocalizedString("notification.verseOfDay.title", comment: "Verse of the day title")
+            content.body = entry.1
+            content.sound = .default
+
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+            let request = UNNotificationRequest(
+                identifier: "\(Self.verseOfDayIdentifierPrefix).\(index)",
+                content: content,
+                trigger: trigger
+            )
+
+            try await add(request)
+        }
+    }
+
+    func cancelVerseOfDay() async {
+        let identifiers = await verseOfDayPendingIdentifiers()
+        guard !identifiers.isEmpty else { return }
+        center.removePendingNotificationRequests(withIdentifiers: identifiers)
+    }
+
+    // MARK: - Helpers
+
+    private func verseOfDayPendingIdentifiers() async -> [String] {
+        await withCheckedContinuation { continuation in
+            center.getPendingNotificationRequests { requests in
+                let identifiers = requests
+                    .map(\.identifier)
+                    .filter { $0.hasPrefix(Self.verseOfDayIdentifierPrefix) }
+                continuation.resume(returning: identifiers)
+            }
+        }
+    }
+
+    private func add(_ request: UNNotificationRequest) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            center.add(request) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    private static let readingReminderIdentifier = "com.kurani.notifications.readingReminder"
+    private static let verseOfDayIdentifierPrefix = "com.kurani.notifications.verseOfDay"
+}

--- a/ViewModels/SettingsViewModel.swift
+++ b/ViewModels/SettingsViewModel.swift
@@ -1,18 +1,227 @@
 import Foundation
 import SwiftUI
+import UserNotifications
 
 @MainActor
 final class SettingsViewModel: ObservableObject {
     @Published var toast: LocalizedStringKey?
+    @Published var readingReminderEnabled: Bool
+    @Published var readingReminderTime: Date
+    @Published var verseOfDayEnabled: Bool
 
     private let progressStore: ReadingProgressStore
+    private let translationStore: TranslationStore
+    private let notificationManager: NotificationManager
+    private let defaults: UserDefaults
 
-    init(progressStore: ReadingProgressStore) {
+    private enum Keys {
+        static let readingReminderEnabled = "settings.readingReminder.enabled"
+        static let readingReminderTime = "settings.readingReminder.time"
+        static let verseOfDayEnabled = "settings.verseOfDay.enabled"
+    }
+
+    init(
+        progressStore: ReadingProgressStore,
+        translationStore: TranslationStore,
+        notificationManager: NotificationManager = .shared,
+        defaults: UserDefaults = .standard
+    ) {
         self.progressStore = progressStore
+        self.translationStore = translationStore
+        self.notificationManager = notificationManager
+        self.defaults = defaults
+
+        let storedTime = defaults.object(forKey: Keys.readingReminderTime) as? Date ?? Self.defaultReminderTime()
+        readingReminderTime = storedTime
+        readingReminderEnabled = defaults.object(forKey: Keys.readingReminderEnabled) as? Bool ?? false
+        verseOfDayEnabled = defaults.object(forKey: Keys.verseOfDayEnabled) as? Bool ?? false
     }
 
     func resetReadingProgress() {
         progressStore.reset()
         toast = LocalizedStringKey("settings.progress.resetSuccess")
+    }
+
+    func setReadingReminderEnabled(_ isOn: Bool) {
+        Task { await handleReadingReminderToggle(isOn) }
+    }
+
+    func updateReadingReminderTime(_ newTime: Date) {
+        readingReminderTime = newTime
+        defaults.set(newTime, forKey: Keys.readingReminderTime)
+
+        guard readingReminderEnabled else { return }
+
+        Task {
+            guard await ensureAuthorization() else {
+                readingReminderEnabled = false
+                defaults.set(false, forKey: Keys.readingReminderEnabled)
+                toast = LocalizedStringKey("settings.notifications.permissionDenied")
+                return
+            }
+
+            let scheduled = await scheduleReadingReminder()
+
+            if scheduled {
+                toast = LocalizedStringKey("settings.notifications.reminderTimeUpdated")
+            } else {
+                readingReminderEnabled = false
+                defaults.set(false, forKey: Keys.readingReminderEnabled)
+                toast = LocalizedStringKey("settings.notifications.error")
+            }
+        }
+    }
+
+    func setVerseOfDayEnabled(_ isOn: Bool) {
+        Task { await handleVerseOfDayToggle(isOn) }
+    }
+
+    // MARK: - Notification Scheduling
+
+    private func handleReadingReminderToggle(_ isOn: Bool) async {
+        if isOn {
+            readingReminderEnabled = true
+
+            guard await ensureAuthorization() else {
+                readingReminderEnabled = false
+                defaults.set(false, forKey: Keys.readingReminderEnabled)
+                toast = LocalizedStringKey("settings.notifications.permissionDenied")
+                return
+            }
+
+            let scheduled = await scheduleReadingReminder()
+            guard scheduled else {
+                readingReminderEnabled = false
+                defaults.set(false, forKey: Keys.readingReminderEnabled)
+                toast = LocalizedStringKey("settings.notifications.error")
+                return
+            }
+
+            defaults.set(true, forKey: Keys.readingReminderEnabled)
+            toast = LocalizedStringKey("settings.notifications.reminderEnabled")
+        } else {
+            readingReminderEnabled = false
+            defaults.set(false, forKey: Keys.readingReminderEnabled)
+            notificationManager.cancelReadingReminder()
+            toast = LocalizedStringKey("settings.notifications.reminderDisabled")
+        }
+    }
+
+    private func scheduleReadingReminder() async -> Bool {
+        var components = Calendar.current.dateComponents([.hour, .minute], from: readingReminderTime)
+        components.second = 0
+
+        do {
+            try await notificationManager.scheduleReadingReminder(at: components)
+            return true
+        } catch {
+            print("Failed to schedule reading reminder", error)
+            return false
+        }
+    }
+
+    private func handleVerseOfDayToggle(_ isOn: Bool) async {
+        if isOn {
+            verseOfDayEnabled = true
+
+            guard await ensureAuthorization() else {
+                verseOfDayEnabled = false
+                defaults.set(false, forKey: Keys.verseOfDayEnabled)
+                toast = LocalizedStringKey("settings.notifications.permissionDenied")
+                return
+            }
+
+            switch await scheduleVerseOfDayNotifications() {
+            case .success:
+                defaults.set(true, forKey: Keys.verseOfDayEnabled)
+                toast = LocalizedStringKey("settings.notifications.verseEnabled")
+            case .noVerses:
+                verseOfDayEnabled = false
+                defaults.set(false, forKey: Keys.verseOfDayEnabled)
+                toast = LocalizedStringKey("settings.notifications.verseUnavailable")
+            case .failure:
+                verseOfDayEnabled = false
+                defaults.set(false, forKey: Keys.verseOfDayEnabled)
+                toast = LocalizedStringKey("settings.notifications.error")
+            }
+        } else {
+            verseOfDayEnabled = false
+            defaults.set(false, forKey: Keys.verseOfDayEnabled)
+            await notificationManager.cancelVerseOfDay()
+            toast = LocalizedStringKey("settings.notifications.verseDisabled")
+        }
+    }
+
+    private enum VerseSchedulingResult {
+        case success
+        case noVerses
+        case failure
+    }
+
+    private func scheduleVerseOfDayNotifications() async -> VerseSchedulingResult {
+        let verses = translationStore.randomAyahs(count: 30)
+        guard !verses.isEmpty else { return .noVerses }
+
+        guard let firstFireDate = Calendar.current.nextDate(
+            after: Date(),
+            matching: DateComponents(hour: 7, minute: 0),
+            matchingPolicy: .nextTime,
+            direction: .forward
+        ) else {
+            return .failure
+        }
+
+        var notifications: [(DateComponents, String)] = []
+        let calendar = Calendar.current
+        let bodyFormat = NSLocalizedString(
+            "notification.verseOfDay.body",
+            comment: "Verse of the day body format"
+        )
+
+        for (index, entry) in verses.enumerated() {
+            guard let fireDate = calendar.date(byAdding: .day, value: index, to: firstFireDate) else { continue }
+            var components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: fireDate)
+            components.second = 0
+
+            let surahName = translationStore.title(for: entry.surah)
+            let body = String(
+                format: bodyFormat,
+                locale: Locale.current,
+                entry.ayah.text,
+                surahName,
+                entry.ayah.number
+            )
+            notifications.append((components, body))
+        }
+
+        guard !notifications.isEmpty else { return .failure }
+
+        do {
+            try await notificationManager.scheduleVerseOfDayNotifications(notifications)
+            return .success
+        } catch {
+            print("Failed to schedule verse of the day notifications", error)
+            return .failure
+        }
+    }
+
+    private func ensureAuthorization() async -> Bool {
+        let status = await notificationManager.authorizationStatus()
+        switch status {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined:
+            return await notificationManager.requestAuthorization()
+        case .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private static func defaultReminderTime() -> Date {
+        let calendar = Calendar.current
+        let now = Date()
+        return calendar.date(bySettingHour: 20, minute: 0, second: 0, of: now) ?? now
     }
 }

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -29,7 +29,10 @@ struct RootView: View {
         _notesViewModel = StateObject(wrappedValue: NotesViewModel(notesStore: notesStore))
         _favoritesViewModel = StateObject(wrappedValue: FavoritesViewModel(favoritesStore: favoritesStore))
         _settingsViewModel = StateObject(
-            wrappedValue: SettingsViewModel(progressStore: progressStore)
+            wrappedValue: SettingsViewModel(
+                progressStore: progressStore,
+                translationStore: translationStore
+            )
         )
     }
 

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -20,6 +20,69 @@ struct SettingsView: View {
                 .listRowInsets(EdgeInsets())
                 .listRowBackground(Color.clear)
 
+                Section(header: Text(LocalizedStringKey("settings.notifications.title"))) {
+                    VStack(alignment: .leading, spacing: 16) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Toggle(
+                                isOn: Binding(
+                                    get: { viewModel.readingReminderEnabled },
+                                    set: { viewModel.setReadingReminderEnabled($0) }
+                                )
+                            ) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(LocalizedStringKey("settings.notifications.readingReminder"))
+                                        .foregroundColor(.kuraniTextPrimary)
+                                    Text(LocalizedStringKey("settings.notifications.readingReminderDescription"))
+                                        .font(.footnote)
+                                        .foregroundColor(.kuraniTextSecondary)
+                                }
+                            }
+                            .toggleStyle(SwitchToggleStyle(tint: Color.kuraniAccentLight))
+
+                            if viewModel.readingReminderEnabled {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Text(LocalizedStringKey("settings.notifications.timeLabel"))
+                                        .font(.footnote)
+                                        .foregroundColor(.kuraniTextSecondary)
+
+                                    DatePicker(
+                                        "",
+                                        selection: Binding(
+                                            get: { viewModel.readingReminderTime },
+                                            set: { viewModel.updateReadingReminderTime($0) }
+                                        ),
+                                        displayedComponents: .hourAndMinute
+                                    )
+                                    .labelsHidden()
+                                    .datePickerStyle(.compact)
+                                }
+                            }
+                        }
+
+                        Divider()
+
+                        Toggle(
+                            isOn: Binding(
+                                get: { viewModel.verseOfDayEnabled },
+                                set: { viewModel.setVerseOfDayEnabled($0) }
+                            )
+                        ) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(LocalizedStringKey("settings.notifications.verseOfDay"))
+                                    .foregroundColor(.kuraniTextPrimary)
+                                Text(LocalizedStringKey("settings.notifications.verseOfDayDescription"))
+                                    .font(.footnote)
+                                    .foregroundColor(.kuraniTextSecondary)
+                            }
+                        }
+                        .toggleStyle(SwitchToggleStyle(tint: Color.kuraniAccentLight))
+                    }
+                    .appleCard()
+                    .padding(.horizontal, 12)
+                }
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+
                 Section(header: Text(LocalizedStringKey("settings.progress.title"))) {
                     VStack(alignment: .leading, spacing: 16) {
                         Text(LocalizedStringKey("settings.progress.description"))


### PR DESCRIPTION
## Summary
- add a notification manager to schedule reading reminders and verse-of-the-day alerts
- extend settings with toggles, time picker, and localized copy for notification preferences
- persist notification choices in the settings view model and source random verses from the translation store

## Testing
- Not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d6c36adb288331b08ec97339e44a03