### PR TITLE
Allow Arabic reader text to wrap across multiple lines

### DIFF
--- a/Views/Components/ArabicSelectableTextView.swift
+++ b/Views/Components/ArabicSelectableTextView.swift
@@ -18,9 +18,13 @@ struct ArabicSelectableTextView: UIViewRepresentable {
         textView.dataDetectorTypes = []
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
+        textView.textContainer.lineBreakMode = .byWordWrapping
+        textView.textContainer.maximumNumberOfLines = 0
+        textView.textContainer.widthTracksTextView = true
         textView.delegate = context.coordinator
         textView.tintColor = UIColor(Color.kuraniAccentLight)
         textView.adjustsFontForContentSizeCategory = true
+        textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         updateTextAttributes(for: textView)
         return textView


### PR DESCRIPTION
## Summary
- ensure the Arabic selectable text view allows multiple lines by configuring the text container
- adjust layout priorities so the text view can expand in portrait orientation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c8db2df88331a59c24e6fcbebb66