### PR TITLE
Streamline notes workflow

### DIFF
--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 "app_name" = "Kurani";
 "tabs.library" = "Suret";
 "tabs.favorites" = "Të preferuarat";
-"tabs.notes" = "Shënimet e mia";
+"tabs.notes" = "Shënime & të preferuara";
 "tabs.settings" = "Cilësimet";
 
 "action.ok" = "U krye";
@@ -139,4 +139,4 @@
 "dictionary.notFound" = "Kjo fjalë nuk gjendet ende në fjalor.";
 "dictionary.meanings" = "Kuptimet";
 "dictionary.notes" = "Shënime";
-"reader.addToFolder" = "Shto në dosje";
+"reader.addToNotes" = "Shto te shënimet";

--- a/Views/NoteEditorView.swift
+++ b/Views/NoteEditorView.swift
@@ -30,7 +30,7 @@ struct NoteEditorView: View {
                             )
                             .shadow(color: Color.kuraniPrimaryBrand.opacity(0.32), radius: 20, y: 14)
                     )
-                    .foregroundColor(.kuraniTextPrimary)
+                    .foregroundColor(.black)
                     .font(KuraniFont.forTextStyle(.body))
             }
             .padding(.horizontal, 20)

--- a/Views/NotesView.swift
+++ b/Views/NotesView.swift
@@ -76,11 +76,11 @@ struct NotesView: View {
                                         VStack(alignment: .leading, spacing: 8) {
                                             Text(displayTitle(for: note))
                                                 .font(KuraniFont.forTextStyle(.headline))
-                                                .foregroundColor(.kuraniTextPrimary)
+                                                .foregroundColor(.black)
                                                 .lineLimit(2)
                                             Text(note.text)
                                                 .font(KuraniFont.forTextStyle(.body))
-                                                .foregroundColor(.kuraniTextPrimary)
+                                                .foregroundColor(.black)
                                                 .lineLimit(3)
                                             Text(String(format: NSLocalizedString("notes.lastUpdated", comment: "updated"), formatted(date: note.updatedAt)))
                                                 .font(KuraniFont.forTextStyle(.caption))
@@ -166,7 +166,7 @@ struct NotesView: View {
     }
 
     private var hasFavoriteContent: Bool {
-        !favoritesStore.favorites.isEmpty || !favoritesStore.folders.isEmpty
+        !favoritesStore.favorites.isEmpty
     }
 
     private func openCreationSheet() {
@@ -285,10 +285,6 @@ struct NotesView: View {
         if !favoritesStore.favorites.isEmpty {
             favoriteAyahsSection
         }
-
-        ForEach(favoritesStore.folders) { folder in
-            favoritesFolderSection(for: folder)
-        }
     }
 
     private var favoriteAyahsSection: some View {
@@ -328,84 +324,8 @@ struct NotesView: View {
         .listRowBackground(Color.clear)
     }
 
-    @ViewBuilder
-    private func favoritesFolderSection(for folder: FavoriteFolder) -> some View {
-        Section(header: favoritesFolderHeader(for: folder)) {
-            if folder.entries.isEmpty {
-                Text(LocalizedStringKey("favorites.folder.empty"))
-                    .font(.system(.footnote, design: .rounded))
-                    .foregroundColor(.kuraniTextSecondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .listRowBackground(Color.clear)
-            } else {
-                ForEach(folder.entries) { entry in
-                    Button {
-                        path.append(ReaderRoute(surah: entry.surah, ayah: entry.ayah))
-                    } label: {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text(favoriteAyahText(for: entry))
-                                .font(.system(.body, design: .serif))
-                                .foregroundColor(.kuraniTextPrimary)
-                                .lineLimit(4)
-
-                            if let note = entry.note, !note.isEmpty {
-                                Text(note)
-                                    .font(KuraniFont.forTextStyle(.callout))
-                                    .foregroundColor(.kuraniAccentLight)
-                                    .lineLimit(3)
-                            }
-
-                            Text(favoriteFolderDetailText(for: entry))
-                                .font(.system(.caption, design: .rounded))
-                                .foregroundColor(.kuraniTextSecondary)
-                        }
-                        .appleCard(cornerRadius: 20)
-                        .padding(.horizontal, 20)
-                    }
-                    .buttonStyle(.plain)
-                    .listRowInsets(EdgeInsets())
-                    .listRowBackground(Color.clear)
-                    .padding(.vertical, 6)
-                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        Button(role: .destructive) {
-                            withAnimation {
-                                favoritesStore.removeEntry(entry, from: folder.id)
-                            }
-                        } label: {
-                            Label(LocalizedStringKey("favorites.remove"), systemImage: "trash")
-                        }
-                    }
-                }
-            }
-        }
-        .listRowBackground(Color.clear)
-    }
-
-    @ViewBuilder
-    private func favoritesFolderHeader(for folder: FavoriteFolder) -> some View {
-        HStack {
-            Text(folder.name)
-            Spacer()
-            Button {
-                withAnimation {
-                    favoritesStore.deleteFolder(folder.id)
-                }
-            } label: {
-                Image(systemName: "trash")
-                    .font(.system(size: 14, weight: .semibold))
-            }
-            .buttonStyle(.borderless)
-            .foregroundStyle(Color.kuraniAccentLight)
-            .accessibilityLabel(LocalizedStringKey("favorites.folder.delete"))
-        }
-    }
-
     private func favoriteAyahText(for favorite: FavoriteAyah) -> String {
         translationStore.ayahs(for: favorite.surah).first(where: { $0.number == favorite.ayah })?.text ?? ""
-    }
-
-    private func favoriteAyahText(for entry: FavoriteFolder.Entry) -> String {
-        translationStore.ayahs(for: entry.surah).first(where: { $0.number == entry.ayah })?.text ?? ""
     }
 
     private func favoriteDetailText(for favorite: FavoriteAyah) -> String {
@@ -413,14 +333,6 @@ struct NotesView: View {
             format: NSLocalizedString("favorites.detail", comment: "favorite metadata"),
             favorite.ayah,
             translationStore.title(for: favorite.surah)
-        )
-    }
-
-    private func favoriteFolderDetailText(for entry: FavoriteFolder.Entry) -> String {
-        String(
-            format: NSLocalizedString("favorites.detail", comment: "favorite metadata"),
-            entry.ayah,
-            translationStore.title(for: entry.surah)
         )
     }
 }
@@ -520,7 +432,7 @@ private struct AddNoteSheet: View {
                 .padding(.vertical, 14)
                 .padding(.horizontal, 16)
                 .background(cardBackground())
-                .foregroundColor(.kuraniTextPrimary)
+                .foregroundColor(.black)
                 .font(KuraniFont.forTextStyle(.body))
         }
     }
@@ -545,7 +457,7 @@ private struct AddNoteSheet: View {
                     .frame(minHeight: 220)
                     .padding(.vertical, 18)
                     .padding(.horizontal, 16)
-                    .foregroundColor(.kuraniTextPrimary)
+                    .foregroundColor(.black)
                     .font(KuraniFont.forTextStyle(.body))
                     .scrollContentBackground(.hidden)
             }

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RootView: View {
-    enum Tab { case library, favorites, notes, settings }
+    enum Tab { case library, notes, settings }
 
     let translationStore: TranslationStore
     let notesStore: NotesStore
@@ -10,7 +10,6 @@ struct RootView: View {
 
     @StateObject private var libraryViewModel: LibraryViewModel
     @StateObject private var notesViewModel: NotesViewModel
-    @StateObject private var favoritesViewModel: FavoritesViewModel
     @StateObject private var settingsViewModel: SettingsViewModel
 
     @State private var selectedTab: Tab = .library
@@ -27,7 +26,6 @@ struct RootView: View {
         self.favoritesStore = favoritesStore
         _libraryViewModel = StateObject(wrappedValue: LibraryViewModel(translationStore: translationStore))
         _notesViewModel = StateObject(wrappedValue: NotesViewModel(notesStore: notesStore))
-        _favoritesViewModel = StateObject(wrappedValue: FavoritesViewModel(favoritesStore: favoritesStore))
         _settingsViewModel = StateObject(
             wrappedValue: SettingsViewModel(
                 progressStore: progressStore,
@@ -46,13 +44,6 @@ struct RootView: View {
                 Label(LocalizedStringKey("tabs.library"), systemImage: "book")
             }
             .tag(Tab.library)
-
-            FavoritesView(viewModel: favoritesViewModel, openNotesTab: { selectedTab = .notes })
-                .background(Color.clear)
-                .tabItem {
-                    Label(LocalizedStringKey("tabs.favorites"), systemImage: "heart")
-                }
-                .tag(Tab.favorites)
 
             NotesView(viewModel: notesViewModel, translationStore: translationStore)
                 .background(Color.clear)


### PR DESCRIPTION
## Summary
- switch note editor and list text colors to black for better readability
- remove the folder picker flow, exposing a single "Add to notes" action and combining favorites within the notes tab
- drop the dedicated favorites tab so saved notes and favorites share one page and adjust tab copy accordingly

## Testing
- Not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6cb151bd4833189d76811389c2a18