### PR TITLE
Adjust fullscreen tap zones for easier scrolling

### DIFF
--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -34,6 +34,9 @@ struct ReaderView: View {
         return formatter
     }()
 
+    private let fullscreenTapZoneHeightTop: CGFloat = 60
+    private let fullscreenTapZoneHeightBottom: CGFloat = 96
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
@@ -268,7 +271,7 @@ struct ReaderView: View {
             ZStack(alignment: .top) {
                 if isChromeHidden {
                     Color.clear
-                        .frame(height: 120)
+                        .frame(height: fullscreenTapZoneHeightTop)
                         .contentShape(Rectangle())
                         .onTapGesture { revealFullscreenChrome() }
                 }
@@ -316,7 +319,7 @@ struct ReaderView: View {
             ZStack(alignment: .bottom) {
                 if isChromeHidden {
                     Color.clear
-                        .frame(height: 140)
+                        .frame(height: fullscreenTapZoneHeightBottom)
                         .contentShape(Rectangle())
                         .onTapGesture { revealFullscreenChrome() }
                 }


### PR DESCRIPTION
## Summary
- shrink the fullscreen chrome tap zones in the reader view to reduce touch interception
- centralize tap zone heights as constants for easier tuning

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6ccd326288331b9328abc494cb37a