### PR TITLE
Add letter A font size controls

### DIFF
--- a/Views/Components/FontSizeButtonLabel.swift
+++ b/Views/Components/FontSizeButtonLabel.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct FontSizeButtonLabel: View {
+    enum Action {
+        case decrease
+        case increase
+    }
+
+    let action: Action
+
+    var body: some View {
+        Text("A")
+            .font(.system(size: fontSize, weight: .semibold))
+            .frame(width: 28, height: 28)
+            .foregroundStyle(Color.kuraniAccentLight)
+            .accessibilityHidden(true)
+    }
+
+    private var fontSize: CGFloat {
+        switch action {
+        case .decrease:
+            return 16
+        case .increase:
+            return 20
+        }
+    }
+}
+
+#Preview {
+    HStack(spacing: 20) {
+        FontSizeButtonLabel(action: .decrease)
+        FontSizeButtonLabel(action: .increase)
+    }
+    .padding()
+    .background(Color.black)
+    .previewLayout(.sizeThatFits)
+}

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -179,17 +179,15 @@ struct ReaderView: View {
                     Button {
                         viewModel.decreaseFont()
                     } label: {
-                        Image(systemName: "textformat.size.smaller")
-                            .accessibilityLabel(LocalizedStringKey("reader.font.decrease"))
-                            .foregroundStyle(Color.kuraniAccentLight)
+                        FontSizeButtonLabel(action: .decrease)
                     }
+                    .accessibilityLabel(LocalizedStringKey("reader.font.decrease"))
                     Button {
                         viewModel.increaseFont()
                     } label: {
-                        Image(systemName: "textformat.size.larger")
-                            .accessibilityLabel(LocalizedStringKey("reader.font.increase"))
-                            .foregroundStyle(Color.kuraniAccentLight)
+                        FontSizeButtonLabel(action: .increase)
                     }
+                    .accessibilityLabel(LocalizedStringKey("reader.font.increase"))
                     Menu {
                         Button(LocalizedStringKey("reader.lineSpacing.decrease")) { viewModel.decreaseLineSpacing() }
                         Button(LocalizedStringKey("reader.lineSpacing.increase")) { viewModel.increaseLineSpacing() }


### PR DESCRIPTION
## Summary
- add a reusable `FontSizeButtonLabel` view that renders the reader font controls as prominent "A" icons
- update the reader toolbar to use the new labels so the font size actions are easier to discover

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d75633bfa083319878b7fde0d1d7b1