### PR TITLE
Fix tab state initialization to avoid crash

### DIFF
--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RootView: View {
-    enum Tab { case library, notes, settings }
+    enum Tab: Hashable { case library, notes, settings }
 
     let translationStore: TranslationStore
     let notesStore: NotesStore
@@ -12,7 +12,7 @@ struct RootView: View {
     @StateObject private var notesViewModel: NotesViewModel
     @StateObject private var settingsViewModel: SettingsViewModel
 
-    @State private var selectedTab: Tab = .library
+    @State private var selectedTab: Tab
 
     init(translationStore: TranslationStore, notesStore: NotesStore, progressStore: ReadingProgressStore, favoritesStore: FavoritesStore) {
         self.translationStore = translationStore
@@ -27,6 +27,7 @@ struct RootView: View {
                 translationStore: translationStore
             )
         )
+        _selectedTab = State(initialValue: .library)
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- make the RootView.Tab enumeration Hashable and initialize the state explicitly to ensure the selection binding is valid

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7648ba0808331bda4a03d794d67e5