### PR TITLE
Adjust reader font controls

### DIFF
--- a/Views/Components/FontSizeButtonLabel.swift
+++ b/Views/Components/FontSizeButtonLabel.swift
@@ -9,8 +9,8 @@ struct FontSizeButtonLabel: View {
     let action: Action
 
     var body: some View {
-        Text("A")
-            .font(.system(size: fontSize, weight: .semibold))
+        Text(symbol)
+            .font(.system(size: fontSize, weight: fontWeight))
             .frame(width: 28, height: 28)
             .foregroundStyle(Color.kuraniAccentLight)
             .accessibilityHidden(true)
@@ -19,9 +19,27 @@ struct FontSizeButtonLabel: View {
     private var fontSize: CGFloat {
         switch action {
         case .decrease:
-            return 16
+            return 18
         case .increase:
             return 20
+        }
+    }
+
+    private var fontWeight: Font.Weight {
+        switch action {
+        case .decrease:
+            return .regular
+        case .increase:
+            return .semibold
+        }
+    }
+
+    private var symbol: String {
+        switch action {
+        case .decrease:
+            return "a"
+        case .increase:
+            return "A"
         }
     }
 }

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -121,14 +121,6 @@ struct ReaderView: View {
                         FontSizeButtonLabel(action: .increase)
                     }
                     .accessibilityLabel(LocalizedStringKey("reader.font.increase"))
-                    Menu {
-                        Button(LocalizedStringKey("reader.lineSpacing.decrease")) { viewModel.decreaseLineSpacing() }
-                        Button(LocalizedStringKey("reader.lineSpacing.increase")) { viewModel.increaseLineSpacing() }
-                    } label: {
-                        Image(systemName: "text.line.first.and.arrowtriangle.forward")
-                            .foregroundStyle(Color.kuraniAccentLight)
-                    }
-                    .accessibilityLabel(LocalizedStringKey("reader.lineSpacing"))
                     Button {
                         openNotesTab()
                     } label: {


### PR DESCRIPTION
## Summary
- update the font size buttons to display a large "A" and small "a" glyph for clearer sizing controls
- remove the overflow menu for line spacing adjustments to simplify the toolbar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d76cbaf5c08331aaef50cb0d13f319