### PR TITLE
Use text glyphs for reader font size buttons

### DIFF
--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -419,17 +419,6 @@ private struct ReaderProgressBar: View {
     }
 }
 
-private struct FontSizeButtonLabel: View {
-    enum Action { case increase, decrease }
-    let action: Action
-
-    var body: some View {
-        let systemName = action == .increase ? "textformat.size.larger" : "textformat.size.smaller"
-        Image(systemName: systemName)
-            .foregroundStyle(Color.kuraniAccentLight)
-    }
-}
-
 private struct AyahRowView: View {
     let ayah: Ayah
     let showAlbanianText: Bool


### PR DESCRIPTION
## Summary
- remove the reader-specific font size button label that used SF Symbols
- rely on the shared FontSizeButtonLabel component so the controls show small and large A glyphs

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d76e7ba96083318678b0e63dc4bfaf