### PR TITLE
Ensure Supabase client reads credentials from Info.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,18 @@ Kurani është një aplikacion SwiftUI për iOS 17 që ofron një përvojë lexi
   aplikacionin.
 
 ## Konfigurimi i Supabase
-1. **Krijo projektin Supabase** dhe shto paketën [`supabase-swift`](https://github.com/supabase-community/supabase-swift) në projekt nëpërmjet Swift Package Manager.
+1. **Krijo projektin Supabase** dhe shto paketën [`supabase-swift`](https://github.com/supabase-community/supabase-swift) në projekt nëpërmjet Swift Package Manager (File > Add Packages… > paste URL-në).
 2. Kopjo skedarin `Config.xcconfig` në projekt dhe lidhe me target-in kryesor.
-   - Plotëso `SUPABASE_URL` dhe `SUPABASE_ANON_KEY` me kredencialet nga Supabase.
-3. Në Supabase SQL Editor ekzekuto skriptin në vijim për të krijuar tabelën e shënimeve dhe politikat e RLS:
+   - Ruaj aty vlerat për `SUPABASE_URL` dhe `SUPABASE_ANON_KEY` për të shmangur përfshirjen e sekreteve në kontrollin e versioneve.
+   - Alternativisht, përdor `xcconfig` ose `User-Defined Setting` në *Build Settings* me `SUPABASE_URL` dhe `SUPABASE_ANON_KEY` të vendosura vetëm në ambientin lokal/CI.
+3. Shto çelësat në `Info.plist` duke përdorur variablat e konfigurimit në vijim:
+   ```xml
+   <key>SUPABASE_URL</key>
+   <string>$(SUPABASE_URL)</string>
+   <key>SUPABASE_ANON_KEY</key>
+   <string>$(SUPABASE_ANON_KEY)</string>
+   ```
+4. Në Supabase SQL Editor ekzekuto skriptin në vijim për të krijuar tabelën e shënimeve dhe politikat e RLS:
    ```sql
    create table if not exists public.notes (
      id uuid primary key default gen_random_uuid(),
@@ -44,8 +52,7 @@ Kurani është një aplikacion SwiftUI për iOS 17 që ofron një përvojë lexi
    using ( auth.uid() = user_id )
    with check ( auth.uid() = user_id );
    ```
-4. Aktivizo ofruesit e autentikimit në Supabase: **Sign in with Apple** dhe **Email (magic link)**. Në panelin e Supabase > Authentication sigurohu që Apple Sign-In të ketë domain dhe redirect URL të konfiguruar sipas udhëzimeve.
-5. Në Xcode, importo `Config.xcconfig` dhe konfiguro target-in për të lexuar çelësat e Supabase në Info.plist.
+5. Aktivizo ofruesit e autentikimit në Supabase: **Sign in with Apple** dhe **Email (magic link)**. Në panelin e Supabase > Authentication sigurohu që Apple Sign-In të ketë domain dhe redirect URL të konfiguruar sipas udhëzimeve.
 6. Përditëso Info.plist:
    - `CFBundleDevelopmentRegion = sq`
    - `CFBundleDisplayName = Kurani`

--- a/Supabase/SupabaseClientProvider.swift
+++ b/Supabase/SupabaseClientProvider.swift
@@ -1,15 +1,21 @@
 import Foundation
 import Supabase
 
-final class SupabaseClientProvider {
-    static let shared = SupabaseClientProvider()
-
-    let client: SupabaseClient
-
-    private init() {
+enum SupabaseClientProvider {
+    static let client: SupabaseClient = {
         let bundle = Bundle.main
-        let urlString = bundle.object(forInfoDictionaryKey: "SUPABASE_URL") as? String ?? "https://example.supabase.co"
-        let anonKey = bundle.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String ?? ""
-        client = SupabaseClient(supabaseURL: URL(string: urlString)!, supabaseKey: anonKey)
-    }
+
+        guard
+            let urlString = bundle.object(forInfoDictionaryKey: "SUPABASE_URL") as? String,
+            let url = URL(string: urlString)
+        else {
+            fatalError("Missing or invalid SUPABASE_URL in Info.plist")
+        }
+
+        guard let anonKey = bundle.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String, !anonKey.isEmpty else {
+            fatalError("Missing SUPABASE_ANON_KEY in Info.plist")
+        }
+
+        return SupabaseClient(supabaseURL: url, supabaseKey: anonKey)
+    }()
 }


### PR DESCRIPTION
## Summary
- update the Supabase client provider to read Supabase configuration from Info.plist and fail fast when keys are missing
- document how to add the Supabase Swift package, configure the Info.plist keys, and keep credentials out of source control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d776253d00833188a8ec16d6cb428c