### PR TITLE
Replace local reading tabs with Supabase-backed readers

### DIFF
--- a/Data/TranslationStore.swift
+++ b/Data/TranslationStore.swift
@@ -92,3 +92,38 @@ final class TranslationStore: ObservableObject {
         }
     }
 }
+
+#if DEBUG
+extension TranslationStore {
+    static func previewStore() -> TranslationStore {
+        let service = PreviewTranslationService()
+        let store = TranslationStore(service: service)
+        store.surahs = service.sampleSurahs
+        store.ayahsBySurah = service.sampleAyahs
+        return store
+    }
+}
+
+private struct PreviewTranslationService: TranslationService {
+    let sampleSurahs: [Surah] = [
+        Surah(number: 1, name: "Al-Fatiha", ayahCount: 7),
+        Surah(number: 2, name: "Al-Baqara", ayahCount: 286)
+    ]
+
+    let sampleAyahs: [Int: [Ayah]] = [
+        1: [
+            Ayah(number: 1, text: "Lavdi i qoftë Allahut, Zotit të botëve", arabicText: "ٱلْحَمْدُ لِلَّهِ رَبِّ ٱلْعَالَمِينَ"),
+            Ayah(number: 2, text: "Mëshiruesi, Mëshirëploti", arabicText: "ٱلرَّحْمَٰنِ ٱلرَّحِيمِ")
+        ],
+        2: [
+            Ayah(number: 255, text: "Allahu! Nuk ka zot tjetër përveç Atij", arabicText: "ٱللَّهُ لَآ إِلَٰهَ إِلَّا هُوَ")
+        ]
+    ]
+
+    func fetchSurahMetadata() async throws -> [Surah] { sampleSurahs }
+
+    func fetchAyahsBySurah() async throws -> [Int: [Ayah]] { sampleAyahs }
+
+    func fetchArabicTextBySurah() async throws -> [Int: [Int: String]] { [:] }
+}
+#endif

--- a/Supabase/QuranService.swift
+++ b/Supabase/QuranService.swift
@@ -1,6 +1,16 @@
 import Foundation
 import Supabase
 
+protocol QuranServicing {
+    func loadTranslationWords(surah: Int, ayah: Int?) async throws -> [TranslationWord]
+    func rebuildAlbanianAyah(surah: Int, ayah: Int) async throws -> String
+    func getMyNotesForSurah(surah: Int) async throws -> [NoteRow]
+    func upsertMyNote(surah: Int, ayah: Int, albanianText: String, note: String) async throws
+    func isFavorite(surah: Int, ayah: Int) async throws -> Bool
+    func toggleFavorite(surah: Int, ayah: Int) async throws
+    func loadMyFavouritesView() async throws -> [FavoriteViewRow]
+}
+
 enum QuranServiceError: LocalizedError {
     case unauthenticated
     case supabase(message: String)
@@ -15,7 +25,7 @@ enum QuranServiceError: LocalizedError {
     }
 }
 
-final class QuranService {
+final class QuranService: QuranServicing {
     private let client: SupabaseClient
 
     init(client: SupabaseClient = SupabaseClientProvider.client) {

--- a/Views/AlbanianReadingView.swift
+++ b/Views/AlbanianReadingView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 
 struct AlbanianReadingView: View {
-    private struct NoteRoute: Identifiable, Hashable {
-        let id: Int
+    private struct NoteEditorConfiguration: Identifiable {
+        let id = UUID()
+        let ayah: Int
+        let albanianText: String
+        let existingNote: String
     }
 
     private struct AlertContent: Identifiable {
@@ -12,7 +15,7 @@ struct AlbanianReadingView: View {
     }
 
     let surah: Int
-    private let quranService = QuranService()
+    private let quranService: QuranServicing
 
     @EnvironmentObject private var translationStore: TranslationStore
     @EnvironmentObject private var favoritesStore: FavoritesStore
@@ -22,89 +25,73 @@ struct AlbanianReadingView: View {
     @State private var noteTexts: [Int: String] = [:]
     @State private var isLoading = false
     @State private var loadError: String?
-    @State private var noteRoute: NoteRoute?
-    @State private var albanianDraft: String = ""
-    @State private var noteDraft: String = ""
-    @State private var isSavingNote = false
+    @State private var noteEditor: NoteEditorConfiguration?
     @State private var alertContent: AlertContent?
 
-    init(surah: Int = 1) {
+    init(surah: Int = 1, quranService: QuranServicing = QuranService()) {
         self.surah = surah
+        self.quranService = quranService
     }
 
     var body: some View {
-        NavigationStack {
-            Group {
-                if isLoading {
-                    ProgressView()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else if let loadError {
-                    VStack(spacing: 16) {
-                        Text(loadError)
-                            .multilineTextAlignment(.center)
-                            .font(KuraniFont.forTextStyle(.body))
-                            .foregroundColor(.kuraniTextSecondary)
-                        Button(action: { Task { await loadContent() } }) {
-                            Text(LocalizedStringKey("Retry"))
-                                .font(KuraniFont.forTextStyle(.body))
-                        }
-                        .buttonStyle(.borderedProminent)
-                    }
+        Group {
+            if isLoading {
+                ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                } else {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 18) {
-                            if totalAyahs == 0 {
-                                Text(LocalizedStringKey("No verses available"))
-                                    .font(KuraniFont.forTextStyle(.body))
-                                    .foregroundColor(.kuraniTextSecondary)
-                                    .frame(maxWidth: .infinity, alignment: .center)
-                            } else {
-                                ForEach(1..<(totalAyahs + 1), id: \.self) { ayah in
-                                    ayahCard(for: ayah)
-                                }
+            } else if let loadError {
+                VStack(spacing: 16) {
+                    Text(loadError)
+                        .multilineTextAlignment(.center)
+                        .font(KuraniFont.forTextStyle(.body))
+                        .foregroundColor(.kuraniTextSecondary)
+                    Button(action: { Task { await loadContent() } }) {
+                        Text(LocalizedStringKey("Retry"))
+                            .font(KuraniFont.forTextStyle(.body))
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        if totalAyahs == 0 {
+                            Text(LocalizedStringKey("No verses available"))
+                                .font(KuraniFont.forTextStyle(.body))
+                                .foregroundColor(.kuraniTextSecondary)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        } else {
+                            ForEach(1..<(totalAyahs + 1), id: \.self) { ayah in
+                                ayahCard(for: ayah)
                             }
                         }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 24)
                     }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 24)
                 }
             }
-            .navigationTitle(navigationTitle)
-            .background(KuraniTheme.background.ignoresSafeArea())
-            .task {
-                if totalAyahs == 0 && !isLoading {
-                    await loadContent()
-                }
-            }
-            .sheet(item: $noteRoute) { route in
-                AlbanianNoteEditorView(
-                    ayahNumber: route.id,
-                    surahNumber: surah,
-                    surahTitle: navigationTitle,
-                    albanianDraft: $albanianDraft,
-                    noteDraft: $noteDraft,
-                    isSaving: isSavingNote,
-                    onCancel: { noteRoute = nil },
-                    onSave: { saveNote(for: route.id) }
-                )
-            }
-            .alert(item: $alertContent) { alert in
-                Alert(
-                    title: Text(alert.title),
-                    message: Text(alert.message),
-                    dismissButton: .default(Text(LocalizedStringKey("OK")))
-                )
+        }
+        .background(KuraniTheme.background.ignoresSafeArea())
+        .task {
+            if totalAyahs == 0 && !isLoading {
+                await loadContent()
             }
         }
-    }
-
-    private var navigationTitle: String {
-        let title = translationStore.title(for: surah)
-        if title.isEmpty {
-            return String(format: NSLocalizedString("Surah %d", comment: "surah title"), surah)
+        .sheet(item: $noteEditor, onDismiss: { Task { await loadContent() } }) { configuration in
+            NoteEditorView(
+                surah: surah,
+                ayah: configuration.ayah,
+                initialText: configuration.albanianText,
+                existingNote: configuration.existingNote,
+                quranService: quranService
+            )
         }
-        return title
+        .alert(item: $alertContent) { alert in
+            Alert(
+                title: Text(alert.title),
+                message: Text(alert.message),
+                dismissButton: .default(Text(LocalizedStringKey("OK")))
+            )
+        }
     }
 
     private func loadContent() async {
@@ -203,155 +190,26 @@ struct AlbanianReadingView: View {
     }
 
     private func openNoteEditor(for ayah: Int) {
-        albanianDraft = ayahTexts[ayah] ?? ""
-        noteDraft = noteTexts[ayah] ?? ""
-        noteRoute = NoteRoute(id: ayah)
-    }
-
-    private func saveNote(for ayah: Int) {
-        Task {
-            await MainActor.run {
-                isSavingNote = true
-            }
-            do {
-                try await quranService.upsertMyNote(
-                    surah: surah,
-                    ayah: ayah,
-                    albanianText: albanianDraft,
-                    note: noteDraft
-                )
-                await MainActor.run {
-                    ayahTexts[ayah] = albanianDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-                    noteTexts[ayah] = noteDraft
-                    isSavingNote = false
-                    noteRoute = nil
-                }
-            } catch {
-                await MainActor.run {
-                    isSavingNote = false
-                    alertContent = AlertContent(
-                        title: NSLocalizedString("Error", comment: "error"),
-                        message: error.localizedDescription
-                    )
-                }
-            }
-        }
+        let configuration = NoteEditorConfiguration(
+            ayah: ayah,
+            albanianText: ayahTexts[ayah] ?? "",
+            existingNote: noteTexts[ayah] ?? ""
+        )
+        noteEditor = configuration
     }
 }
 
-private struct AlbanianNoteEditorView: View {
-    let ayahNumber: Int
-    let surahNumber: Int
-    let surahTitle: String
-    @Binding var albanianDraft: String
-    @Binding var noteDraft: String
-    let isSaving: Bool
-    let onCancel: () -> Void
-    let onSave: () -> Void
+#if DEBUG
+#Preview {
+    let translationStore = TranslationStore.previewStore()
+    let favoritesStore = FavoritesStore()
+    let authManager = AuthManager.previewManager()
 
-    @FocusState private var focusedField: Field?
-
-    private enum Field {
-        case albanian
-        case note
-    }
-
-    var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text(displayedSurahTitle)
-                            .font(KuraniFont.forTextStyle(.subheadline))
-                            .foregroundColor(.kuraniTextSecondary)
-                        Text(String(format: NSLocalizedString("Ayah %d", comment: "ayah title"), ayahNumber))
-                            .font(KuraniFont.forTextStyle(.headline))
-                            .foregroundColor(.kuraniTextPrimary)
-                    }
-
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text(LocalizedStringKey("Albanian Text"))
-                            .font(KuraniFont.forTextStyle(.callout))
-                            .foregroundColor(.kuraniTextSecondary)
-                        TextEditor(text: $albanianDraft)
-                            .focused($focusedField, equals: .albanian)
-                            .frame(minHeight: 160)
-                            .padding(.vertical, 18)
-                            .padding(.horizontal, 16)
-                            .background(
-                                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                    .fill(Color.kuraniPrimarySurface.opacity(0.58))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                            .stroke(Color.kuraniPrimaryBrand.opacity(0.12), lineWidth: 0.8)
-                                    )
-                            )
-                            .foregroundColor(.kuraniTextPrimary)
-                            .font(KuraniFont.forTextStyle(.body))
-                    }
-
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text(LocalizedStringKey("Personal Note"))
-                            .font(KuraniFont.forTextStyle(.callout))
-                            .foregroundColor(.kuraniTextSecondary)
-                        TextEditor(text: $noteDraft)
-                            .focused($focusedField, equals: .note)
-                            .frame(minHeight: 120)
-                            .padding(.vertical, 18)
-                            .padding(.horizontal, 16)
-                            .background(
-                                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                    .fill(Color.kuraniPrimarySurface.opacity(0.58))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 20, style: .continuous)
-                                            .stroke(Color.kuraniPrimaryBrand.opacity(0.12), lineWidth: 0.8)
-                                    )
-                            )
-                            .foregroundColor(.kuraniTextPrimary)
-                            .font(KuraniFont.forTextStyle(.body))
-                    }
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 24)
-            }
-            .background(KuraniTheme.background.ignoresSafeArea())
-            .navigationTitle(LocalizedStringKey("Edit Note"))
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(action: onCancel) {
-                        Text(LocalizedStringKey("action.cancel"))
-                            .font(KuraniFont.forTextStyle(.body))
-                    }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(action: onSave) {
-                        if isSaving {
-                            ProgressView()
-                        } else {
-                            Text(LocalizedStringKey("action.ok"))
-                                .font(KuraniFont.forTextStyle(.body))
-                                .fontWeight(.semibold)
-                        }
-                    }
-                    .disabled(albanianDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
-                }
-            }
-            .tint(.kuraniAccentLight)
-            .onAppear {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    focusedField = .albanian
-                }
-            }
-        }
+    return NavigationStack {
+        AlbanianReadingView(surah: 1, quranService: MockQuranService())
+            .environmentObject(translationStore)
+            .environmentObject(favoritesStore)
+            .environmentObject(authManager)
     }
 }
-
-private extension AlbanianNoteEditorView {
-    var displayedSurahTitle: String {
-        let trimmed = surahTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return String(format: NSLocalizedString("Surah %d", comment: "surah title"), surahNumber)
-        }
-        return trimmed
-    }
-}
+#endif

--- a/Views/ArabicReadingView.swift
+++ b/Views/ArabicReadingView.swift
@@ -17,8 +17,11 @@ struct ArabicReadingView: View {
         }
     }
 
-    private struct NoteRoute: Identifiable, Hashable {
-        let id: Int
+    private struct NoteEditorConfiguration: Identifiable {
+        let id = UUID()
+        let ayah: Int
+        let initialText: String
+        let existingNote: String
     }
 
     private struct AlertContent: Identifiable {
@@ -29,11 +32,10 @@ struct ArabicReadingView: View {
 
     let surah: Int
     let scrollToAyah: Int?
-    private let quranService = QuranService()
+    private let quranService: QuranServicing
 
     @EnvironmentObject private var notesStore: NotesStore
     @EnvironmentObject private var favoritesStore: FavoritesStore
-    @EnvironmentObject private var translationStore: TranslationStore
 
     @State private var ayahNumbers: [Int] = []
     @State private var wordsByAyah: [Int: [TranslationWord]] = [:]
@@ -41,98 +43,85 @@ struct ArabicReadingView: View {
     @State private var loadError: String?
     @State private var selectedMode: LanguageMode = .arabic
     @State private var activeAlert: AlertContent?
-    @State private var noteRoute: NoteRoute?
-    @State private var noteDraft: String = ""
-    @State private var isSavingNote = false
+    @State private var noteEditor: NoteEditorConfiguration?
     @State private var pendingScrollAyah: Int?
 
-    init(surah: Int, scrollToAyah: Int? = nil) {
+    init(surah: Int, scrollToAyah: Int? = nil, quranService: QuranServicing = QuranService()) {
         self.surah = surah
         self.scrollToAyah = scrollToAyah
+        self.quranService = quranService
         _pendingScrollAyah = State(initialValue: scrollToAyah)
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollViewReader { proxy in
-                Group {
-                    if isLoading {
-                        ProgressView()
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else if let loadError {
-                        VStack(spacing: 16) {
-                            Text(loadError)
-                                .multilineTextAlignment(.center)
-                                .font(KuraniFont.forTextStyle(.body))
-                                .foregroundColor(.kuraniTextSecondary)
-                            Button(action: { Task { await loadWords() } }) {
-                                Text(LocalizedStringKey("Retry"))
-                                    .font(KuraniFont.forTextStyle(.body))
-                            }
-                            .buttonStyle(.borderedProminent)
-                        }
+        ScrollViewReader { proxy in
+            Group {
+                if isLoading {
+                    ProgressView()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    } else {
-                        ScrollView {
-                            VStack(alignment: .leading, spacing: 18) {
-                                Picker("Mode", selection: $selectedMode) {
-                                    ForEach(LanguageMode.allCases) { mode in
-                                        Text(mode.title)
-                                            .tag(mode)
-                                    }
-                                }
-                                .pickerStyle(.segmented)
-
-                                ForEach(ayahNumbers, id: \.self) { ayah in
-                                    ayahView(ayah)
-                                        .id(ayah)
+                } else if let loadError {
+                    VStack(spacing: 16) {
+                        Text(loadError)
+                            .multilineTextAlignment(.center)
+                            .font(KuraniFont.forTextStyle(.body))
+                            .foregroundColor(.kuraniTextSecondary)
+                        Button(action: { Task { await loadWords() } }) {
+                            Text(LocalizedStringKey("Retry"))
+                                .font(KuraniFont.forTextStyle(.body))
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 18) {
+                            Picker("Mode", selection: $selectedMode) {
+                                ForEach(LanguageMode.allCases) { mode in
+                                    Text(mode.title)
+                                        .tag(mode)
                                 }
                             }
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 24)
+                            .pickerStyle(.segmented)
+
+                            ForEach(ayahNumbers, id: \.self) { ayah in
+                                ayahView(ayah)
+                                    .id(ayah)
+                            }
                         }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 24)
                     }
                 }
-                .onChange(of: ayahNumbers) { _ in
-                    scrollToPendingAyah(proxy)
-                }
-                .onChange(of: pendingScrollAyah) { _ in
-                    scrollToPendingAyah(proxy)
-                }
             }
-            .navigationTitle(navigationTitle)
-            .background(KuraniTheme.background.ignoresSafeArea())
-            .task {
-                if ayahNumbers.isEmpty && !isLoading {
-                    await loadWords()
-                }
+            .onChange(of: ayahNumbers) { _ in
+                scrollToPendingAyah(proxy)
             }
-            .navigationDestination(item: $noteRoute) { route in
-                let ayahModel = ayahModel(for: route.id)
-                BoundNoteEditorView(
-                    ayah: ayahModel,
-                    draft: $noteDraft,
-                    isSaving: isSavingNote,
-                    onCancel: { noteRoute = nil },
-                    onSave: { saveNote(for: route.id) }
-                )
-            }
-            .alert(item: $activeAlert) { alert in
-                Alert(
-                    title: Text(alert.title),
-                    message: Text(alert.message),
-                    dismissButton: .default(Text(LocalizedStringKey("OK")))
-                )
+            .onChange(of: pendingScrollAyah) { _ in
+                scrollToPendingAyah(proxy)
             }
         }
-    }
-
-    private var navigationTitle: String {
-        let title = translationStore.title(for: surah)
-        if title.isEmpty {
-            return String(format: NSLocalizedString("Surah %d", comment: "surah title"), surah)
+        .background(KuraniTheme.background.ignoresSafeArea())
+        .task {
+            if ayahNumbers.isEmpty && !isLoading {
+                await loadWords()
+            }
         }
-        return title
+        .sheet(item: $noteEditor, onDismiss: { Task { await notesStore.fetchAll() } }) { configuration in
+            NoteEditorView(
+                surah: surah,
+                ayah: configuration.ayah,
+                initialText: configuration.initialText,
+                existingNote: configuration.existingNote,
+                quranService: quranService
+            )
+        }
+        .alert(item: $activeAlert) { alert in
+            Alert(
+                title: Text(alert.title),
+                message: Text(alert.message),
+                dismissButton: .default(Text(LocalizedStringKey("OK")))
+            )
+        }
     }
 
     private func loadWords() async {
@@ -251,38 +240,9 @@ struct ArabicReadingView: View {
     }
 
     private func openNoteEditor(for ayah: Int) {
-        noteDraft = notesStore.note(for: surah, ayah: ayah)?.text ?? ""
-        noteRoute = NoteRoute(id: ayah)
-    }
-
-    private func saveNote(for ayah: Int) {
-        Task {
-            await MainActor.run {
-                isSavingNote = true
-            }
-            do {
-                try await notesStore.upsertNote(surah: surah, ayah: ayah, title: nil, text: noteDraft)
-                await MainActor.run {
-                    isSavingNote = false
-                    noteRoute = nil
-                }
-            } catch {
-                await MainActor.run {
-                    isSavingNote = false
-                    activeAlert = AlertContent(
-                        title: NSLocalizedString("Error", comment: "Error title"),
-                        message: error.localizedDescription
-                    )
-                }
-            }
-        }
-    }
-
-    private func ayahModel(for number: Int) -> Ayah {
-        let words = wordsByAyah[number] ?? []
-        let albanianText = words.map(\.albanianWord).joined(separator: " ")
-        let arabicText = words.map(\.arabicWord).joined(separator: " ")
-        return Ayah(number: number, text: albanianText, arabicText: arabicText)
+        let albanianText = wordsByAyah[ayah]?.map(\.albanianWord).joined(separator: " ") ?? ""
+        let existingNote = notesStore.note(for: surah, ayah: ayah)?.text ?? ""
+        noteEditor = NoteEditorConfiguration(ayah: ayah, initialText: albanianText, existingNote: existingNote)
     }
 }
 
@@ -356,3 +316,20 @@ private struct WordWrapHeightPreferenceKey: PreferenceKey {
         value = nextValue()
     }
 }
+
+#if DEBUG
+#Preview {
+    let translationStore = TranslationStore.previewStore()
+    let notesStore = NotesStore.previewStore()
+    let favoritesStore = FavoritesStore()
+    let authManager = AuthManager.previewManager()
+
+    return NavigationStack {
+        ArabicReadingView(surah: 1, quranService: MockQuranService())
+            .environmentObject(notesStore)
+            .environmentObject(favoritesStore)
+            .environmentObject(authManager)
+    }
+    .environmentObject(translationStore)
+}
+#endif

--- a/Views/FavouritesView.swift
+++ b/Views/FavouritesView.swift
@@ -6,13 +6,17 @@ struct FavouritesView: View {
         let ayah: Int
     }
 
-    private let quranService = QuranService()
+    private let quranService: QuranServicing
 
     @State private var favourites: [FavoriteViewRow] = []
     @State private var isLoading = false
     @State private var loadError: String?
     @State private var path: [Destination] = []
     @State private var alertMessage: String?
+
+    init(quranService: QuranServicing = QuranService()) {
+        self.quranService = quranService
+    }
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -145,10 +149,17 @@ struct FavouritesView: View {
     }
 }
 
+#if DEBUG
 #Preview {
-    FavouritesView()
-        .environmentObject(TranslationStore())
-        .environmentObject(NotesStore())
-        .environmentObject(FavoritesStore())
-        .environmentObject(ReadingProgressStore())
+    let translationStore = TranslationStore.previewStore()
+    let notesStore = NotesStore.previewStore()
+    let favoritesStore = FavoritesStore()
+    let progressStore = ReadingProgressStore.previewStore()
+
+    return FavouritesView(quranService: MockQuranService())
+        .environmentObject(translationStore)
+        .environmentObject(notesStore)
+        .environmentObject(favoritesStore)
+        .environmentObject(progressStore)
 }
+#endif

--- a/Views/NoteEditorView.swift
+++ b/Views/NoteEditorView.swift
@@ -4,7 +4,7 @@ struct NoteEditorView: View {
     let surah: Int
     let ayah: Int
     @State private var albanianText: String
-    @State private var userNote: String = ""
+    @State private var userNote: String
     @State private var isLoadingAlbanianText = false
     @State private var isSaving = false
     @State private var showSignInPrompt = false
@@ -13,12 +13,14 @@ struct NoteEditorView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var authManager: AuthManager
 
-    private let quranService = QuranService()
+    private let quranService: QuranServicing
 
-    init(surah: Int, ayah: Int, initialText: String) {
+    init(surah: Int, ayah: Int, initialText: String, existingNote: String = "", quranService: QuranServicing = QuranService()) {
         self.surah = surah
         self.ayah = ayah
+        self.quranService = quranService
         _albanianText = State(initialValue: initialText)
+        _userNote = State(initialValue: existingNote)
     }
 
     var body: some View {
@@ -255,3 +257,17 @@ struct BoundNoteEditorView: View {
         }
     }
 }
+
+#if DEBUG
+#Preview {
+    let authManager = AuthManager.previewManager()
+    return NoteEditorView(
+        surah: 1,
+        ayah: 1,
+        initialText: "Lavdi i qoftë Allahut, Zotit të botëve",
+        existingNote: "Kujtesë për falënderim",
+        quranService: MockQuranService()
+    )
+    .environmentObject(authManager)
+}
+#endif

--- a/Views/PreviewMocks.swift
+++ b/Views/PreviewMocks.swift
@@ -1,0 +1,102 @@
+#if DEBUG
+import Foundation
+import Supabase
+
+struct MockQuranService: QuranServicing {
+    let wordsBySurah: [Int: [TranslationWord]]
+    let favourites: [FavoriteViewRow]
+
+    init() {
+        let sampleWords = [
+            TranslationWord(surah: 1, ayah: 1, position: 1, arabicWord: "ٱلْحَمْدُ", albanianWord: "Lavdi"),
+            TranslationWord(surah: 1, ayah: 1, position: 2, arabicWord: "لِلَّهِ", albanianWord: "i takon Allahut"),
+            TranslationWord(surah: 1, ayah: 1, position: 3, arabicWord: "رَبِّ", albanianWord: "Zot"),
+            TranslationWord(surah: 1, ayah: 1, position: 4, arabicWord: "ٱلْعَالَمِينَ", albanianWord: "i botëve"),
+            TranslationWord(surah: 1, ayah: 2, position: 1, arabicWord: "ٱلرَّحْمَٰنِ", albanianWord: "Mëshirues"),
+            TranslationWord(surah: 1, ayah: 2, position: 2, arabicWord: "ٱلرَّحِيمِ", albanianWord: "Mëshirplotë"),
+            TranslationWord(surah: 2, ayah: 255, position: 1, arabicWord: "ٱللَّهُ", albanianWord: "Allahu"),
+            TranslationWord(surah: 2, ayah: 255, position: 2, arabicWord: "لَآ", albanianWord: "nuk"),
+            TranslationWord(surah: 2, ayah: 255, position: 3, arabicWord: "إِلَٰهَ", albanianWord: "ka zot"),
+            TranslationWord(surah: 2, ayah: 255, position: 4, arabicWord: "إِلَّا", albanianWord: "përveç"),
+            TranslationWord(surah: 2, ayah: 255, position: 5, arabicWord: "هُوَ", albanianWord: "Atij"),
+        ]
+
+        wordsBySurah = Dictionary(grouping: sampleWords, by: { $0.surah })
+
+        favourites = [
+            FavoriteViewRow(
+                id: UUID(),
+                userId: UUID(),
+                surah: 1,
+                ayah: 1,
+                createdAt: Date(),
+                arabicAyahText: "ٱلْحَمْدُ لِلَّهِ رَبِّ ٱلْعَالَمِينَ",
+                albanianAyahText: "Lavdi i qoftë Allahut, Zotit të botëve"
+            ),
+            FavoriteViewRow(
+                id: UUID(),
+                userId: UUID(),
+                surah: 2,
+                ayah: 255,
+                createdAt: Date(),
+                arabicAyahText: "ٱللَّهُ لَآ إِلَٰهَ إِلَّا هُوَ",
+                albanianAyahText: "Allahu! Nuk ka zot tjetër përveç Atij"
+            )
+        ]
+    }
+
+    func loadTranslationWords(surah: Int, ayah: Int?) async throws -> [TranslationWord] {
+        if let ayah, let words = wordsBySurah[surah]?.filter({ $0.ayah == ayah }) {
+            return words
+        }
+        return wordsBySurah[surah] ?? []
+    }
+
+    func rebuildAlbanianAyah(surah: Int, ayah: Int) async throws -> String {
+        let words = try await loadTranslationWords(surah: surah, ayah: ayah)
+        return words.map(\.albanianWord).joined(separator: " ")
+    }
+
+    func getMyNotesForSurah(surah: Int) async throws -> [NoteRow] {
+        []
+    }
+
+    func upsertMyNote(surah: Int, ayah: Int, albanianText: String, note: String) async throws {}
+
+    func isFavorite(surah: Int, ayah: Int) async throws -> Bool { false }
+
+    func toggleFavorite(surah: Int, ayah: Int) async throws {}
+
+    func loadMyFavouritesView() async throws -> [FavoriteViewRow] {
+        favourites
+    }
+}
+
+extension NotesStore {
+    static func previewStore() -> NotesStore {
+        let url = URL(string: "https://preview.supabase.co")!
+        let client = SupabaseClient(supabaseURL: url, supabaseKey: "preview-key")
+        let store = NotesStore(client: client)
+        return store
+    }
+}
+
+extension ReadingProgressStore {
+    static func previewStore() -> ReadingProgressStore {
+        let defaults = UserDefaults(suiteName: "preview.reading.progress") ?? .standard
+        let store = ReadingProgressStore(userDefaults: defaults)
+        store.updateHighestAyah(1, for: 1, totalAyahs: 7)
+        store.updateHighestAyah(50, for: 2, totalAyahs: 286)
+        return store
+    }
+}
+
+extension AuthManager {
+    static func previewManager() -> AuthManager {
+        let url = URL(string: "https://preview.supabase.co")!
+        let client = SupabaseClient(supabaseURL: url, supabaseKey: "preview-key")
+        return AuthManager(client: client)
+    }
+}
+
+#endif

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -1,62 +1,228 @@
 import SwiftUI
 
 struct RootView: View {
-    enum Tab: Hashable { case library, notes, settings }
+    enum Tab: Hashable { case arabic, albanian, favourites, notes }
 
     let translationStore: TranslationStore
     let notesStore: NotesStore
-    let progressStore: ReadingProgressStore
-    let favoritesStore: FavoritesStore
+    let quranServiceFactory: () -> QuranServicing
 
-    @StateObject private var libraryViewModel: LibraryViewModel
     @StateObject private var notesViewModel: NotesViewModel
-    @StateObject private var settingsViewModel: SettingsViewModel
 
     @State private var selectedTab: Tab
+    @State private var arabicSurahSelection: Int
+    @State private var albanianSurahSelection: Int
+    @AppStorage(AppStorageKeys.lastReadSurah) private var persistedSurah = 1
 
-    init(translationStore: TranslationStore, notesStore: NotesStore, progressStore: ReadingProgressStore, favoritesStore: FavoritesStore) {
+    init(
+        translationStore: TranslationStore,
+        notesStore: NotesStore,
+        progressStore: ReadingProgressStore,
+        favoritesStore: FavoritesStore,
+        quranServiceFactory: @escaping () -> QuranServicing = { QuranService() }
+    ) {
         self.translationStore = translationStore
         self.notesStore = notesStore
-        self.progressStore = progressStore
-        self.favoritesStore = favoritesStore
-        _libraryViewModel = StateObject(wrappedValue: LibraryViewModel(translationStore: translationStore))
+        self.quranServiceFactory = quranServiceFactory
+        _ = progressStore
+        _ = favoritesStore
+
+        let storedSurah = UserDefaults.standard.integer(forKey: AppStorageKeys.lastReadSurah)
+        let initialSurah = storedSurah > 0 ? storedSurah : 1
+
         _notesViewModel = StateObject(wrappedValue: NotesViewModel(notesStore: notesStore))
-        _settingsViewModel = StateObject(
-            wrappedValue: SettingsViewModel(
-                progressStore: progressStore,
-                translationStore: translationStore
-            )
-        )
-        _selectedTab = State(initialValue: .library)
+        _selectedTab = State(initialValue: .arabic)
+        _arabicSurahSelection = State(initialValue: initialSurah)
+        _albanianSurahSelection = State(initialValue: initialSurah)
     }
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            LibraryView(viewModel: libraryViewModel) {
-                selectedTab = .notes
-            }
-            .background(Color.clear)
+            ArabicReaderTab(
+                selectedSurah: $arabicSurahSelection,
+                persistedSurah: $persistedSurah,
+                quranService: quranServiceFactory()
+            )
             .tabItem {
-                Label(LocalizedStringKey("tabs.library"), systemImage: "book")
+                Label("Lexo (AR)", systemImage: "book.closed")
             }
-            .tag(Tab.library)
+            .tag(Tab.arabic)
+
+            AlbanianReaderTab(
+                selectedSurah: $albanianSurahSelection,
+                persistedSurah: $persistedSurah,
+                quranService: quranServiceFactory()
+            )
+            .tabItem {
+                Label("Lexo (SQ)", systemImage: "book")
+            }
+            .tag(Tab.albanian)
+
+            FavouritesView()
+                .tabItem {
+                    Label("Të preferuarat", systemImage: "heart")
+                }
+                .tag(Tab.favourites)
 
             NotesView(viewModel: notesViewModel, translationStore: translationStore)
-                .background(Color.clear)
                 .tabItem {
-                    Label(LocalizedStringKey("tabs.notes"), systemImage: "note.text")
+                    Label("Shënimet", systemImage: "note.text")
                 }
                 .tag(Tab.notes)
-
-            SettingsView(viewModel: settingsViewModel)
-                .background(Color.clear)
-                .tabItem {
-                    Label(LocalizedStringKey("tabs.settings"), systemImage: "gearshape")
-                }
-                .tag(Tab.settings)
         }
         .tint(Color.kuraniAccentBrand)
         .background(KuraniTheme.background.ignoresSafeArea())
     }
 }
 
+private struct ArabicReaderTab: View {
+    @EnvironmentObject private var translationStore: TranslationStore
+    @Binding var selectedSurah: Int
+    @Binding var persistedSurah: Int
+    private let quranService: QuranServicing
+
+    init(
+        selectedSurah: Binding<Int>,
+        persistedSurah: Binding<Int>,
+        quranService: QuranServicing = QuranService()
+    ) {
+        _selectedSurah = selectedSurah
+        _persistedSurah = persistedSurah
+        self.quranService = quranService
+    }
+
+    var body: some View {
+        NavigationStack {
+            ArabicReadingView(surah: selectedSurah, quranService: quranService)
+                .navigationTitle(title(for: selectedSurah))
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Menu {
+                            ForEach(translationStore.surahs) { surah in
+                                Button {
+                                    selectedSurah = surah.number
+                                } label: {
+                                    if surah.number == selectedSurah {
+                                        Label(title(for: surah.number), systemImage: "checkmark")
+                                    } else {
+                                        Text(title(for: surah.number))
+                                    }
+                                }
+                            }
+                        } label: {
+                            Label(LocalizedStringKey("reader.changeSurah"), systemImage: "list.number")
+                        }
+                        .disabled(translationStore.surahs.isEmpty)
+                    }
+                }
+        }
+        .onAppear(perform: ensureValidSelection)
+        .onChange(of: translationStore.surahs) { _ in ensureValidSelection() }
+        .onChange(of: selectedSurah) { newValue in
+            persistedSurah = newValue
+        }
+    }
+
+    private func ensureValidSelection() {
+        guard let first = translationStore.surahs.first else { return }
+        if !translationStore.surahs.contains(where: { $0.number == selectedSurah }) {
+            selectedSurah = first.number
+        }
+    }
+
+    private func title(for surah: Int) -> String {
+        let title = translationStore.title(for: surah)
+        if title.isEmpty {
+            return String(format: NSLocalizedString("Surah %d", comment: "surah title"), surah)
+        }
+        return title
+    }
+}
+
+private struct AlbanianReaderTab: View {
+    @EnvironmentObject private var translationStore: TranslationStore
+    @Binding var selectedSurah: Int
+    @Binding var persistedSurah: Int
+    private let quranService: QuranServicing
+
+    init(
+        selectedSurah: Binding<Int>,
+        persistedSurah: Binding<Int>,
+        quranService: QuranServicing = QuranService()
+    ) {
+        _selectedSurah = selectedSurah
+        _persistedSurah = persistedSurah
+        self.quranService = quranService
+    }
+
+    var body: some View {
+        NavigationStack {
+            AlbanianReadingView(surah: selectedSurah, quranService: quranService)
+                .navigationTitle(title(for: selectedSurah))
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Menu {
+                            ForEach(translationStore.surahs) { surah in
+                                Button {
+                                    selectedSurah = surah.number
+                                } label: {
+                                    if surah.number == selectedSurah {
+                                        Label(title(for: surah.number), systemImage: "checkmark")
+                                    } else {
+                                        Text(title(for: surah.number))
+                                    }
+                                }
+                            }
+                        } label: {
+                            Label(LocalizedStringKey("reader.changeSurah"), systemImage: "list.number")
+                        }
+                        .disabled(translationStore.surahs.isEmpty)
+                    }
+                }
+        }
+        .onAppear(perform: ensureValidSelection)
+        .onChange(of: translationStore.surahs) { _ in ensureValidSelection() }
+        .onChange(of: selectedSurah) { newValue in
+            persistedSurah = newValue
+        }
+    }
+
+    private func ensureValidSelection() {
+        guard let first = translationStore.surahs.first else { return }
+        if !translationStore.surahs.contains(where: { $0.number == selectedSurah }) {
+            selectedSurah = first.number
+        }
+    }
+
+    private func title(for surah: Int) -> String {
+        let title = translationStore.title(for: surah)
+        if title.isEmpty {
+            return String(format: NSLocalizedString("Surah %d", comment: "surah title"), surah)
+        }
+        return title
+    }
+}
+
+#if DEBUG
+#Preview {
+    let translationStore = TranslationStore.previewStore()
+    let notesStore = NotesStore.previewStore()
+    let favoritesStore = FavoritesStore()
+    let progressStore = ReadingProgressStore.previewStore()
+    let authManager = AuthManager.previewManager()
+    let quranService = MockQuranService()
+
+    return RootView(
+        translationStore: translationStore,
+        notesStore: notesStore,
+        progressStore: progressStore,
+        favoritesStore: favoritesStore,
+        quranServiceFactory: { quranService }
+    )
+    .environmentObject(translationStore)
+    .environmentObject(notesStore)
+    .environmentObject(favoritesStore)
+    .environmentObject(progressStore)
+    .environmentObject(authManager)
+}
+#endif


### PR DESCRIPTION
## Summary
- replace the old library/settings navigation with a four-tab reader that surfaces the Arabic and Albanian Supabase readers, favourites, and notes
- update Arabic and Albanian reader flows to launch the shared Supabase-powered NoteEditorView and inject Quran services for live/preview data
- add reusable mock services and stores so SwiftUI previews compile without hitting Supabase

## Testing
- Not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7855691f48331af431b14f63827a1