### PR TITLE
Refine Supabase client provider

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -3,8 +3,8 @@ import SwiftUI
 @main
 struct KuraniApp: App {
     @StateObject private var translationStore = TranslationStore()
-    @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.shared.client)
-    @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.shared.client)
+    @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.client)
+    @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.client)
     @StateObject private var progressStore = ReadingProgressStore()
     @StateObject private var favoritesStore = FavoritesStore()
 

--- a/Supabase/Secrets.swift
+++ b/Supabase/Secrets.swift
@@ -14,32 +14,54 @@ enum Secrets {
             }
         }
     }
+}
 
-    private static let bundle = Bundle.main
+struct SecretsLoader {
+    private let bundle: Bundle
 
-    static func supabaseConfiguration() throws -> (url: URL, anonKey: String) {
+    init(bundle: Bundle = .main) {
+        self.bundle = bundle
+    }
+
+    func supabaseConfiguration() throws -> (url: URL, anonKey: String) {
         let url = try supabaseURL()
         let anonKey = try supabaseAnonKey()
         return (url, anonKey)
     }
 
-    static func supabaseURL() throws -> URL {
+    func supabaseURL() throws -> URL {
         guard let value = bundle.object(forInfoDictionaryKey: "SUPABASE_URL") as? String, !value.isEmpty else {
-            throw SecretsError.missingValue(key: "SUPABASE_URL")
+            throw Secrets.SecretsError.missingValue(key: "SUPABASE_URL")
         }
 
         guard let url = URL(string: value) else {
-            throw SecretsError.invalidURL(key: "SUPABASE_URL")
+            throw Secrets.SecretsError.invalidURL(key: "SUPABASE_URL")
         }
 
         return url
     }
 
-    static func supabaseAnonKey() throws -> String {
+    func supabaseAnonKey() throws -> String {
         guard let value = bundle.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String, !value.isEmpty else {
-            throw SecretsError.missingValue(key: "SUPABASE_ANON_KEY")
+            throw Secrets.SecretsError.missingValue(key: "SUPABASE_ANON_KEY")
         }
 
         return value
+    }
+}
+
+extension Secrets {
+    private static let loader = SecretsLoader()
+
+    static func supabaseConfiguration() throws -> (url: URL, anonKey: String) {
+        try loader.supabaseConfiguration()
+    }
+
+    static func supabaseURL() throws -> URL {
+        try loader.supabaseURL()
+    }
+
+    static func supabaseAnonKey() throws -> String {
+        try loader.supabaseAnonKey()
     }
 }

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var translationStore = TranslationStore()
-    @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.shared.client)
-    @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.shared.client)
+    @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.client)
+    @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.client)
     @StateObject private var favoritesStore = FavoritesStore()
     @StateObject private var progressStore = ReadingProgressStore()
 


### PR DESCRIPTION
## Summary
- convert `SupabaseClientProvider` into a singleton-backed class that relies on the reusable `SecretsLoader`
- standardize Supabase client access across the app and previews to the updated API
- add a DEBUG-only diagnostic confirming Supabase configuration loads without exposing secrets

## Testing
- Not run (not supported in containerized environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7975ee504833195d7193b0c420780