### PR TITLE
Add missing Supabase models for favorites and dictionary

### DIFF
--- a/Supabase/ArabicDictionaryEntry.swift
+++ b/Supabase/ArabicDictionaryEntry.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct ArabicDictionaryEntry: Codable, Identifiable, Hashable {
+    let id: String
+    let word: String
+    let transliteration: String
+    let meanings: [String]
+    let notes: String?
+}

--- a/Supabase/FavoriteRow.swift
+++ b/Supabase/FavoriteRow.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct FavoriteRow: Codable, Hashable {
+    let id: UUID?
+    let userId: UUID?
+    let surah: Int?
+    let ayah: Int?
+    let createdAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case surah
+        case ayah
+        case createdAt = "created_at"
+    }
+}

--- a/Supabase/FavoriteViewRow.swift
+++ b/Supabase/FavoriteViewRow.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct FavoriteViewRow: Codable, Hashable, Identifiable {
+    let id: UUID
+    let userId: UUID
+    let surah: Int
+    let ayah: Int
+    let createdAt: Date
+    let arabicAyahText: String?
+    let albanianAyahText: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case surah
+        case ayah
+        case createdAt = "created_at"
+        case arabicAyahText = "arabic_ayah_text"
+        case albanianAyahText = "albanian_ayah_text"
+    }
+}

--- a/Supabase/QuranService.swift
+++ b/Supabase/QuranService.swift
@@ -188,8 +188,9 @@ private extension QuranService {
     }
 
     func mapSupabaseError(_ error: Error) -> Error {
-        if let supabaseError = error as? SupabaseError {
-            return QuranServiceError.supabase(message: supabaseError.errorDescription ?? supabaseError.localizedDescription)
+        if let localizedError = error as? LocalizedError {
+            let description = localizedError.errorDescription ?? localizedError.localizedDescription
+            return QuranServiceError.supabase(message: description)
         }
         return error
     }


### PR DESCRIPTION
## Summary
- add Supabase models for favorite rows, favorite view rows, and dictionary entries so the service compiles
- update Supabase error mapping to use localized error descriptions when present

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7a94151e4833199e9fc6780d9bcd8