### PR TITLE
Fix missing Supabase model references in Xcode project

### DIFF
--- a/Kurani.xcodeproj/project.pbxproj
+++ b/Kurani.xcodeproj/project.pbxproj
@@ -43,7 +43,11 @@ D4F6B6D22C9F000100000092 /* ArabicDictionary.swift in Sources */ = {isa = PBXBui
 D4F6B6D42C9F000100000094 /* ArabicSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6D52C9F000100000095 /* ArabicSelectableTextView.swift */; };
                 D4F6B6D62C9F000100000096 /* ArabicDictionaryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B6D72C9F000100000097 /* ArabicDictionaryDetailView.swift */; };
                 F8643BD45C394BFFA5D99674 /* ReadingProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A788809F18B943D3B6063A5A /* ReadingProgressStore.swift */; };
-                D4FF6AB12D000001000000A1 /* TranslationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF6AB02D000001000000A0 /* TranslationService.swift */; };
+               D4FF6AB12D000001000000A1 /* TranslationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF6AB02D000001000000A0 /* TranslationService.swift */; };
+               D4FF6AB32D000001000000A3 /* TranslationWord.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF6AB22D000001000000A2 /* TranslationWord.swift */; };
+               D4FF6AB52D000001000000A5 /* NoteRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF6AB42D000001000000A4 /* NoteRow.swift */; };
+               D4FF6AB72D000001000000A7 /* FavoriteRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF6AB62D000001000000A6 /* FavoriteRow.swift */; };
+               D4FF6AB92D000001000000A9 /* FavoriteViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FF6AB82D000001000000A8 /* FavoriteViewRow.swift */; };
                 D4F6B7A42C9F0001000000D3 /* QuranService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B7A32C9F0001000000D2 /* QuranService.swift */; };
                 D4F6B7A62C9F0001000000D5 /* QuranServicing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F6B7A52C9F0001000000D4 /* QuranServicing.swift */; };
                 E4474F56488F4C62929FB0C8 /* ProgressBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333054A5288A4EB490D5C514 /* ProgressBadge.swift */; };
@@ -77,7 +81,11 @@ D4F6B6D12C9F000100000091 /* ArabicDictionaryEntry.swift */ = {isa = PBXFileRefer
                 D47AD4DA2A6B02A300000025 /* NotesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesStore.swift; sourceTree = "<group>"; };
 		D47AD4DA2A6B02A300000026 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
                 D47AD4DA2A6B02A300000027 /* SupabaseClientProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClientProvider.swift; sourceTree = "<group>"; };
-                D4FF6AB02D000001000000A0 /* TranslationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationService.swift; sourceTree = "<group>"; };
+               D4FF6AB02D000001000000A0 /* TranslationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationService.swift; sourceTree = "<group>"; };
+               D4FF6AB22D000001000000A2 /* TranslationWord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationWord.swift; sourceTree = "<group>"; };
+               D4FF6AB42D000001000000A4 /* NoteRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteRow.swift; sourceTree = "<group>"; };
+               D4FF6AB62D000001000000A6 /* FavoriteRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRow.swift; sourceTree = "<group>"; };
+               D4FF6AB82D000001000000A8 /* FavoriteViewRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewRow.swift; sourceTree = "<group>"; };
                 D47AD4DA2A6B02A300000028 /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 D47AD4DA2A6B02A30000002A /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 D47AD4DA2A6B02A30000002B /* AppStorageKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKeys.swift; sourceTree = "<group>"; };
@@ -205,12 +213,16 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
                D47AD4DA2A6B02A300000013 /* Supabase */ = {
                         isa = PBXGroup;
                         children = (
-                                D47AD4DA2A6B02A300000025 /* NotesStore.swift */,
-                                D47AD4DA2A6B02A300000026 /* AuthManager.swift */,
-                                D47AD4DA2A6B02A300000027 /* SupabaseClientProvider.swift */,
-                                D4F6B7A32C9F0001000000D2 /* QuranService.swift */,
-                                D4F6B7A52C9F0001000000D4 /* QuranServicing.swift */,
-                                D4FF6AB02D000001000000A0 /* TranslationService.swift */,
+                               D47AD4DA2A6B02A300000025 /* NotesStore.swift */,
+                               D47AD4DA2A6B02A300000026 /* AuthManager.swift */,
+                               D47AD4DA2A6B02A300000027 /* SupabaseClientProvider.swift */,
+                               D4FF6AB42D000001000000A4 /* NoteRow.swift */,
+                               D4FF6AB62D000001000000A6 /* FavoriteRow.swift */,
+                               D4FF6AB82D000001000000A8 /* FavoriteViewRow.swift */,
+                               D4FF6AB22D000001000000A2 /* TranslationWord.swift */,
+                               D4F6B7A32C9F0001000000D2 /* QuranService.swift */,
+                               D4F6B7A52C9F0001000000D4 /* QuranServicing.swift */,
+                               D4FF6AB02D000001000000A0 /* TranslationService.swift */,
                         );
 			path = Supabase;
 			sourceTree = "<group>";
@@ -341,10 +353,14 @@ D4FF6AAA2D00000100000090 /* Fonts */ = {isa = PBXFileReference; lastKnownFileTyp
                                 D4FF6AAA2D00000100000093 /* KuraniFont.swift in Sources */,
                                 D47AD4DA2A6B02A300000044 /* ShareSheet.swift in Sources */,
                                 D4F6B6D22C9F000100000092 /* ArabicDictionary.swift in Sources */,
-                                D4F6B7A42C9F0001000000D3 /* QuranService.swift in Sources */,
-                                D4F6B7A62C9F0001000000D5 /* QuranServicing.swift in Sources */,
-                                D47AD4DA2A6B02A300000043 /* SupabaseClientProvider.swift in Sources */,
-                                D4FF6AB12D000001000000A1 /* TranslationService.swift in Sources */,
+                               D4FF6AB72D000001000000A7 /* FavoriteRow.swift in Sources */,
+                               D4FF6AB92D000001000000A9 /* FavoriteViewRow.swift in Sources */,
+                               D4FF6AB52D000001000000A5 /* NoteRow.swift in Sources */,
+                               D4FF6AB32D000001000000A3 /* TranslationWord.swift in Sources */,
+                               D4F6B7A42C9F0001000000D3 /* QuranService.swift in Sources */,
+                               D4F6B7A62C9F0001000000D5 /* QuranServicing.swift in Sources */,
+                               D47AD4DA2A6B02A300000043 /* SupabaseClientProvider.swift in Sources */,
+                               D4FF6AB12D000001000000A1 /* TranslationService.swift in Sources */,
                                 D47AD4DA2A6B02A300000042 /* AuthManager.swift in Sources */,
 				D47AD4DA2A6B02A300000041 /* NotesStore.swift in Sources */,
 				D47AD4DA2A6B02A300000040 /* Note.swift in Sources */,


### PR DESCRIPTION
## Summary
- add the Supabase model source files to the Xcode project so protocol references resolve during builds

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7b25aee2c8331a430c38edfc1257a