### PR TITLE
Revise reader navigation layout

### DIFF
--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -83,7 +83,7 @@ struct ReaderView: View {
             .toolbarColorScheme(.light, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    ReaderProgressTitle(title: viewModel.surahTitle, percentage: viewModel.progressPercentageString)
+                    ReaderProgressTitle(title: viewModel.surahTitle)
                 }
             }
             .tint(Color.kuraniAccentLight)
@@ -147,22 +147,18 @@ struct ReaderView: View {
                     }
 
                     if !isChromeHidden {
-                        HStack {
-                            Spacer()
-                            ReaderToolbarControls(
-                                isChromeHidden: isChromeHidden,
-                                showAlbanianText: showAlbanianText,
-                                showArabicText: showArabicText,
-                                onToggleChrome: toggleChrome,
-                                onToggleAlbanian: toggleAlbanian,
-                                onToggleArabic: toggleArabic,
-                                onDecreaseFont: viewModel.decreaseFont,
-                                onIncreaseFont: viewModel.increaseFont,
-                                onOpenNotes: openNotesTab
-                            )
-                            .padding(.horizontal, 8)
-                        }
-                        .padding(.horizontal, 16)
+                        ReaderToolbarControls(
+                            isChromeHidden: isChromeHidden,
+                            showAlbanianText: showAlbanianText,
+                            showArabicText: showArabicText,
+                            onToggleChrome: toggleChrome,
+                            onToggleAlbanian: toggleAlbanian,
+                            onToggleArabic: toggleArabic,
+                            onDecreaseFont: viewModel.decreaseFont,
+                            onIncreaseFont: viewModel.increaseFont,
+                            onOpenNotes: openNotesTab
+                        )
+                        .frame(maxWidth: .infinity, alignment: .trailing)
                         .transition(.move(edge: .top).combined(with: .opacity))
                     }
 
@@ -195,29 +191,16 @@ struct ReaderView: View {
                         .foregroundStyle(Color.kuraniAccentLight)
                     }
                 }
-                .padding(.top, 40)
+                .padding(.top, 16)
                 .padding(.horizontal, 16)
             }
         }
         .overlay(alignment: .bottom) {
-            ZStack(alignment: .bottom) {
-                if isChromeHidden {
-                    Color.clear
-                        .frame(height: fullscreenTapZoneHeightBottom)
-                        .contentShape(Rectangle())
-                        .onTapGesture { revealFullscreenChrome() }
-                }
-
-                if viewModel.totalAyahs > 0, !isChromeHidden || fullscreenControlsVisible {
-                    ReaderProgressBar(
-                        progress: viewModel.readingProgress,
-                        percentage: viewModel.progressPercentageString,
-                        detail: viewModel.progressDescription,
-                        isChromeHidden: isChromeHidden
-                    )
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 24)
-                }
+            if isChromeHidden {
+                Color.clear
+                    .frame(height: fullscreenTapZoneHeightBottom)
+                    .contentShape(Rectangle())
+                    .onTapGesture { revealFullscreenChrome() }
             }
         }
         .onChange(of: viewModel.toast) { _, newValue in
@@ -431,51 +414,11 @@ private struct ReaderToolbarControls: View {
 
 private struct ReaderProgressTitle: View {
     let title: String
-    let percentage: String
 
     var body: some View {
-        HStack(spacing: 8) {
-            Text(title)
-                .font(.system(.headline, design: .rounded))
-                .foregroundColor(.white)
-
-            ProgressBadge(percentage: percentage)
-        }
-    }
-}
-
-private struct ReaderProgressBar: View {
-    let progress: Double
-    let percentage: String
-    let detail: String
-    let isChromeHidden: Bool
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text(percentage)
-                    .font(.system(.subheadline, design: .rounded))
-                    .foregroundColor(.kuraniTextPrimary)
-                Spacer()
-                Text(detail)
-                    .font(.system(.caption, design: .rounded))
-                    .foregroundColor(.kuraniTextSecondary)
-            }
-
-            ProgressView(value: progress)
-                .progressViewStyle(.linear)
-                .tint(.kuraniAccentLight)
-        }
-        .padding(.vertical, 12)
-        .padding(.horizontal, 16)
-        .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(Color.kuraniPrimarySurface.opacity(isChromeHidden ? 0.72 : 0.9))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .stroke(Color.black.opacity(0.12), lineWidth: 0.6)
-                )
-        )
+        Text(title)
+            .font(.system(.headline, design: .rounded))
+            .foregroundColor(.white)
     }
 }
 


### PR DESCRIPTION
## Summary
- make the library tab the primary landing page and remove the separate Arabic/Albanian reader tabs
- pin the reader toolbar to the top and strip percentage indicators from the reading UI

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d7bf3fdf608331baf75dfe7183e089