### PR TITLE
Add ChatGPT lookup button to Arabic dictionary entries

### DIFF
--- a/Resources/sq.lproj/Localizable.strings
+++ b/Resources/sq.lproj/Localizable.strings
@@ -143,4 +143,5 @@
 "dictionary.notFound" = "Kjo fjalë nuk gjendet ende në fjalor.";
 "dictionary.meanings" = "Kuptimet";
 "dictionary.notes" = "Shënime";
+"dictionary.askChatGPT" = "Pyet ChatGPT";
 "reader.addToNotes" = "Shto te shënimet";

--- a/Views/Components/ArabicDictionaryDetailView.swift
+++ b/Views/Components/ArabicDictionaryDetailView.swift
@@ -2,6 +2,12 @@ import SwiftUI
 
 struct ArabicDictionaryDetailView: View {
     let entry: ArabicDictionaryEntry
+    let onAskChatGPT: (() -> Void)?
+
+    init(entry: ArabicDictionaryEntry, onAskChatGPT: (() -> Void)? = nil) {
+        self.entry = entry
+        self.onAskChatGPT = onAskChatGPT
+    }
 
     var body: some View {
         ScrollView {
@@ -39,6 +45,18 @@ struct ArabicDictionaryDetailView: View {
                             .foregroundColor(.kuraniTextSecondary)
                             .fixedSize(horizontal: false, vertical: true)
                     }
+                }
+
+                if let onAskChatGPT {
+                    Button(action: onAskChatGPT) {
+                        HStack {
+                            Image(systemName: "sparkles")
+                            Text(LocalizedStringKey("dictionary.askChatGPT"))
+                                .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(GradientButtonStyle())
                 }
             }
             .padding(24)

--- a/Views/ReaderView.swift
+++ b/Views/ReaderView.swift
@@ -120,7 +120,9 @@ struct ReaderView: View {
             ShareSheet(items: [shareText])
         }
         .sheet(item: $selectedDictionaryEntry) { entry in
-            ArabicDictionaryDetailView(entry: entry)
+            ArabicDictionaryDetailView(entry: entry) {
+                askChatGPT(aboutWord: entry.word)
+            }
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
@@ -234,6 +236,15 @@ struct ReaderView: View {
 
     private func askChatGPT(about ayah: Ayah) {
         let prompt = "Më trego më shumë rreth sures \(viewModel.surahTitle), ajeti \(ayah.number). Teksti: \(ayah.text)"
+        openChatGPT(with: prompt)
+    }
+
+    private func askChatGPT(aboutWord word: String) {
+        let prompt = "Përshëndetje! Më trego më shumë për kuptimin e fjalës \"\(word)\" në arabisht."
+        openChatGPT(with: prompt)
+    }
+
+    private func openChatGPT(with prompt: String) {
         guard let encodedPrompt = prompt.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
         guard let url = URL(string: "https://chat.openai.com/?q=\(encodedPrompt)") else { return }
         openURL(url)


### PR DESCRIPTION
## Summary
- add a ChatGPT action to the Arabic dictionary detail sheet for selected words
- refactor the reader view helper to share ChatGPT prompt building and add localization for the new button label

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7c24d3d388331a72e4bb2c66df134