### PR TITLE
Handle Supabase configuration errors gracefully

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -1,14 +1,43 @@
 import SwiftUI
+import Supabase
 
 @main
 struct KuraniApp: App {
     @StateObject private var translationStore = TranslationStore()
-    @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.client)
-    @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.client)
+    @StateObject private var notesStore: NotesStore
+    @StateObject private var authManager: AuthManager
     @StateObject private var progressStore = ReadingProgressStore()
     @StateObject private var favoritesStore = FavoritesStore()
+    #if DEBUG
+    @State private var configurationError: Error?
+    #endif
 
     init() {
+        let configurationResult = SupabaseClientProvider.configurationResult()
+        let client: SupabaseClient?
+        #if DEBUG
+        let debugConfigurationError: Error?
+        #endif
+
+        switch configurationResult {
+        case .success(let provider):
+            client = provider.client
+            #if DEBUG
+            debugConfigurationError = nil
+            #endif
+        case .failure(let error):
+            client = nil
+            #if DEBUG
+            debugConfigurationError = error
+            #endif
+        }
+
+        _notesStore = StateObject(wrappedValue: NotesStore(client: client))
+        _authManager = StateObject(wrappedValue: AuthManager(client: client))
+        #if DEBUG
+        _configurationError = State(initialValue: debugConfigurationError)
+        #endif
+
         let navigationBarAppearance = UINavigationBar.appearance()
         navigationBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor(Color.kuraniTextPrimary)]
         navigationBarAppearance.titleTextAttributes = [.foregroundColor: UIColor(Color.kuraniTextPrimary)]
@@ -32,6 +61,46 @@ struct KuraniApp: App {
                     await translationStore.loadInitialData()
                     await notesStore.observeAuthChanges(authManager: authManager)
                 }
+                #if DEBUG
+                .overlay(alignment: .top) {
+                    if let message = configurationErrorMessage {
+                        DebugConfigurationBanner(message: message)
+                            .padding(.top, 16)
+                    }
+                }
+                #endif
         }
     }
 }
+
+#if DEBUG
+private struct DebugConfigurationBanner: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.footnote)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color.red.opacity(0.9), in: Capsule())
+            .foregroundColor(.white)
+            .shadow(radius: 4)
+            .accessibilityIdentifier("SupabaseConfigurationBanner")
+    }
+}
+
+private extension KuraniApp {
+    var configurationErrorMessage: String? {
+        guard let configurationError else { return nil }
+        let description: String
+        if let localizedError = configurationError as? LocalizedError,
+           let localizedDescription = localizedError.errorDescription, !localizedDescription.isEmpty {
+            description = localizedDescription
+        } else {
+            description = configurationError.localizedDescription
+        }
+        return "Supabase configuration error: \(description)"
+    }
+}
+#endif

--- a/Supabase/AuthService.swift
+++ b/Supabase/AuthService.swift
@@ -7,7 +7,10 @@ import UIKit
 
 @MainActor
 final class AuthService: NSObject {
-    static let shared = AuthService(client: SupabaseClientProvider.client)
+    static func shared(bundle: Bundle = .main) throws -> AuthService {
+        let client = try SupabaseClientProvider.client(bundle: bundle)
+        return AuthService(client: client)
+    }
 
     private let client: SupabaseClient
     private var appleCoordinator: AppleSignInCoordinator?

--- a/Supabase/Secrets.swift
+++ b/Supabase/Secrets.swift
@@ -30,11 +30,28 @@ struct SecretsLoader {
     }
 
     func supabaseURL() throws -> URL {
-        guard let value = bundle.object(forInfoDictionaryKey: "SUPABASE_URL") as? String, !value.isEmpty else {
+        guard let rawValue = bundle.object(forInfoDictionaryKey: "SUPABASE_URL") as? String else {
             throw Secrets.SecretsError.missingValue(key: "SUPABASE_URL")
         }
 
-        guard let url = URL(string: value) else {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            throw Secrets.SecretsError.missingValue(key: "SUPABASE_URL")
+        }
+
+        guard var components = URLComponents(string: value) else {
+            throw Secrets.SecretsError.invalidURL(key: "SUPABASE_URL")
+        }
+
+        guard let scheme = components.scheme?.lowercased(), scheme == "https" else {
+            throw Secrets.SecretsError.invalidURL(key: "SUPABASE_URL")
+        }
+
+        guard let host = components.host, !host.isEmpty else {
+            throw Secrets.SecretsError.invalidURL(key: "SUPABASE_URL")
+        }
+
+        guard let url = components.url else {
             throw Secrets.SecretsError.invalidURL(key: "SUPABASE_URL")
         }
 
@@ -42,7 +59,13 @@ struct SecretsLoader {
     }
 
     func supabaseAnonKey() throws -> String {
-        guard let value = bundle.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String, !value.isEmpty else {
+        guard let rawValue = bundle.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String else {
+            throw Secrets.SecretsError.missingValue(key: "SUPABASE_ANON_KEY")
+        }
+
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !value.isEmpty else {
             throw Secrets.SecretsError.missingValue(key: "SUPABASE_ANON_KEY")
         }
 

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var translationStore = TranslationStore()
-    @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.client)
-    @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.client)
+    @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.clientIfAvailable())
+    @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.clientIfAvailable())
     @StateObject private var favoritesStore = FavoritesStore()
     @StateObject private var progressStore = ReadingProgressStore()
 
@@ -30,7 +30,7 @@ struct ContentView: View {
 #if DEBUG
 extension NotesStore {
     static func previewStore() -> NotesStore {
-        NotesStore(client: SupabaseClientProvider.client)
+        NotesStore(client: SupabaseClientProvider.clientIfAvailable())
     }
 }
 #Preview {


### PR DESCRIPTION
## Summary
- replace the Supabase client singleton with a thread-safe lazy initializer that caches failures and provides a throwing accessor
- trim and validate Supabase URL and anon key secrets before returning them
- surface configuration issues during DEBUG builds with a lightweight banner and update consumers to tolerate missing clients

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68d7e385faec833193104c464caeed6b