### PR TITLE
Use translation words for Arabic selection

### DIFF
--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -131,6 +131,16 @@ final class ReaderViewModel: ObservableObject {
         favoriteAyahIds.contains(FavoriteAyah.id(for: surahNumber, ayah: ayah.number))
     }
 
+    func translationWords(for ayah: Ayah) async throws -> [TranslationWord] {
+        try await translationStore.translationWords(for: surahNumber, ayah: ayah.number)
+    }
+
+    func translationWord(for ayah: Ayah, at index: Int) async throws -> TranslationWord? {
+        let words = try await translationWords(for: ayah)
+        guard index >= 0, index < words.count else { return nil }
+        return words[index]
+    }
+
     private func resolvedTitle(for ayah: Ayah) -> String {
         if let existing = note(for: ayah)?.title?.trimmingCharacters(in: .whitespacesAndNewlines), !existing.isEmpty {
             return existing


### PR DESCRIPTION
## Summary
- cache translation words per ayah through TranslationStore by calling QuranService
- surface cached translation words in ReaderViewModel/ReaderView and show the Albanian word when long-pressing Arabic text
- update the Arabic text selection view to report tapped token indices instead of raw substrings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7e7499fa48331af8f9bf6a4888ff9