### PR TITLE
Add debug logs for key ayah availability and word counts

### DIFF
--- a/Data/TranslationStore.swift
+++ b/Data/TranslationStore.swift
@@ -28,6 +28,9 @@ final class TranslationStore: ObservableObject {
         hasLoadedInitialData = true
 
         loadAlbanianText()
+#if DEBUG
+        logAlbanianAvailability(for: [1, 2], ayahRange: 1...5)
+#endif
         if !arabicAyahsBySurah.isEmpty {
             applyArabicTextToLocalDataset()
         }
@@ -130,8 +133,36 @@ final class TranslationStore: ObservableObject {
             }
             ayahsBySurah[surahNumber] = ayahs
         }
+#if DEBUG
+        logArabicWordCounts(for: [1, 2], ayahRange: 1...5)
+#endif
     }
 }
+
+#if DEBUG
+private extension TranslationStore {
+    func logAlbanianAvailability(for surahNumbers: [Int], ayahRange: ClosedRange<Int>) {
+        for surah in surahNumbers {
+            for ayahNumber in ayahRange {
+                let ayah = ayahsBySurah[surah]?.first(where: { $0.number == ayahNumber })
+                let hasText = !(ayah?.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                print("Loaded AL(surah:\(surah), ayah:\(ayahNumber)) available:\(hasText)")
+            }
+        }
+    }
+
+    func logArabicWordCounts(for surahNumbers: [Int], ayahRange: ClosedRange<Int>) {
+        for surah in surahNumbers {
+            for ayahNumber in ayahRange {
+                let ayah = ayahsBySurah[surah]?.first(where: { $0.number == ayahNumber })
+                let arabicText = ayah?.arabicText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let wordCount = arabicText.isEmpty ? 0 : arabicText.split { $0.isWhitespace }.count
+                print("Loaded AR(surah:\(surah), ayah:\(ayahNumber)) wordCount:\(wordCount)")
+            }
+        }
+    }
+}
+#endif
 
 private extension TranslationStore {
     struct TranslationWordCacheKey: Hashable {


### PR DESCRIPTION
## Summary
- add debug-only logging after loading Albanian text to surface availability for Surah 1–2, ayahs 1–5
- emit debug logs after applying Arabic text that report word counts for the same ayahs
- centralize the debug logging helpers for reuse within TranslationStore

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e9e59e688331bcbf9b10745353f8