### PR TITLE
Synchronize favorites with Supabase in reader

### DIFF
--- a/App/QuranApp.swift
+++ b/App/QuranApp.swift
@@ -7,7 +7,7 @@ struct KuraniApp: App {
     @StateObject private var notesStore: NotesStore
     @StateObject private var authManager: AuthManager
     @StateObject private var progressStore = ReadingProgressStore()
-    @StateObject private var favoritesStore = FavoritesStore()
+    @StateObject private var favoritesStore: FavoritesStore
     #if DEBUG
     @State private var configurationError: Error?
     #endif
@@ -34,6 +34,7 @@ struct KuraniApp: App {
 
         _notesStore = StateObject(wrappedValue: NotesStore(client: client))
         _authManager = StateObject(wrappedValue: AuthManager(client: client))
+        _favoritesStore = StateObject(wrappedValue: FavoritesStore(client: client))
         #if DEBUG
         _configurationError = State(initialValue: debugConfigurationError)
         #endif

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -4,8 +4,12 @@ struct ContentView: View {
     @StateObject private var translationStore = TranslationStore()
     @StateObject private var notesStore = NotesStore(client: SupabaseClientProvider.clientIfAvailable())
     @StateObject private var authManager = AuthManager(client: SupabaseClientProvider.clientIfAvailable())
-    @StateObject private var favoritesStore = FavoritesStore()
+    @StateObject private var favoritesStore: FavoritesStore
     @StateObject private var progressStore = ReadingProgressStore()
+
+    init() {
+        _favoritesStore = StateObject(wrappedValue: FavoritesStore(client: SupabaseClientProvider.clientIfAvailable()))
+    }
 
     var body: some View {
         RootView(


### PR DESCRIPTION
## Summary
- inject an optional QuranServicing into ReaderViewModel so Supabase favorites are toggled remotely before updating local state and toast on failure
- extend FavoritesStore with remote-aware toggling plus a reusable setter, and instantiate it with the Supabase client when available
- update the Albanian and Arabic reading views to confirm favorite state with Supabase and keep the local cache consistent when calls fail

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7ead1e89483318c894457c68689dd