### PR TITLE
Refine Arabic text fetching and caching

### DIFF
--- a/ViewModels/ReaderViewModel.swift
+++ b/ViewModels/ReaderViewModel.swift
@@ -77,6 +77,7 @@ final class ReaderViewModel: ObservableObject {
     func loadAyahs() {
         ayahs = translationStore.ayahs(for: surahNumber)
         totalAyahs = translationStore.ayahCount(for: surahNumber)
+        Task { await translationStore.ensureArabicText(for: surahNumber, prefetchNextSurahCount: 1) }
         refreshProgress()
     }
 


### PR DESCRIPTION
## Summary
- allow the Supabase translation service to fetch and cache specific surah or ayah ranges while keeping track of cached data
- update the translation store to request Arabic text lazily per surah, prefetch adjacent chapters, and hydrate the translation word cache from the same rows
- trigger the new surah-level Arabic fetch from the reader view model so the active and next surahs are loaded

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7edfa2c6c83318a2fae009444ea1b