### PR TITLE
Add debug button to run Arabic/Albanian scope check

### DIFF
--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -121,6 +121,21 @@ struct SettingsView: View {
                 .listRowInsets(EdgeInsets())
                 .listRowBackground(Color.clear)
 
+#if DEBUG
+                Section(header: Text("Developer")) {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Button("Run Arabic/Albanian scope check") {
+                            viewModel.runArabicAlbanianScopeCheck()
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .appleCard()
+                    .padding(.horizontal, 12)
+                }
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+#endif
+
                 Section(header: Text(LocalizedStringKey("settings.about"))) {
                     VStack(alignment: .leading, spacing: 12) {
                         Text(LocalizedStringKey("settings.about.disclaimer"))


### PR DESCRIPTION
## Summary
- add a DEBUG-only developer section in SettingsView with a scope check button
- implement view model logic to reuse the startup translation word diagnostics for Surah 1 and 2:1-5 and log/toast the results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f0ac658c8331a753121e06554a5d